### PR TITLE
Background colour for the scene

### DIFF
--- a/rqt_graph/src/rqt_graph/ros_graph.py
+++ b/rqt_graph/src/rqt_graph/ros_graph.py
@@ -121,6 +121,7 @@ class RosGraph(Plugin):
             self._widget.setWindowTitle(self._widget.windowTitle() + (' (%d)' % context.serial_number()))
 
         self._scene = QGraphicsScene()
+        self._scene.setBackgroundBrush(Qt.white)
         self._widget.graphics_view.setScene(self._scene)
 
         self._widget.graph_type_combo_box.insertItem(0, self.tr('Nodes only'), NODE_NODE_GRAPH)


### PR DESCRIPTION
The rqt graph plugin shows up badly in dark coloured qt themes (black ellipses on a dark background). Usually it's just a mild annoyance, but found myself writing a similar plugin and caught the lines of code where the scene rendering is done in rqt graph, so here's a patch.

Note: I usually don't like forcing colours in an themed application, but in a rendered scene, your theme doesn't have a choice over the colours of the components (black ellipses for the nodes, etc), so it's choice of matching background is often wrong. This helps with that. 
