### PR TITLE
delay node initialization for python plugins until start of plugins (#67)

### DIFF
--- a/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.h
+++ b/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.h
@@ -55,6 +55,8 @@ public:
 
 protected:
 
+  void wait_for_master();
+
   void init_node();
 
   bool node_initialized_;

--- a/rqt_gui_py/package.xml
+++ b/rqt_gui_py/package.xml
@@ -14,9 +14,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>qt_gui</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rospy</build_depend>
 
+  <run_depend version_gte="0.2.17">qt_gui</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>rospy</run_depend>
   

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -34,6 +34,7 @@ import rospy
 from qt_gui.composite_plugin_provider import CompositePluginProvider
 
 from python_qt_binding.QtCore import qDebug, qWarning
+from python_qt_binding.QtGui import QMessageBox
 
 try:
     from rqt_gui.rospkg_plugin_provider import RospkgPluginProvider
@@ -50,27 +51,22 @@ class RosPyPluginProvider(CompositePluginProvider):
         self.setObjectName('RosPyPluginProvider')
         self._node_initialized = False
 
-    def discover(self):
-        descriptors = super(RosPyPluginProvider, self).discover()
-
-        if not self._master_found():
-            qWarning('RosPyPluginProvider.discover() could not find ROS master, all rospy-based plugins are disabled')
-            # mark all plugins as "not_available"
-            for descriptor in descriptors:
-                descriptor.attributes()['not_available'] = 'no ROS master found (roscore needs to be started before the GUI)'
-
-        return descriptors
-
     def load(self, plugin_id, plugin_context):
+        self._wait_for_master()
         self._init_node()
         return super(RosPyPluginProvider, self).load(plugin_id, plugin_context)
 
-    def _master_found(self):
-        try:
-            rospy.get_master().getSystemState()
-            return True
-        except Exception:
-            return False
+    def _wait_for_master(self):
+        while True:
+            try:
+                rospy.get_master().getSystemState()
+                break
+            except Exception:
+                mb = QMessageBox(QMessageBox.Question, self.tr('Waiting for ROS master'), self.tr("Could not find ROS master. Either start a 'roscore' and retry or abort loading the plugin."), QMessageBox.Retry | QMessageBox.Abort)
+                mb.setDefaultButton(QMessageBox.Retry)
+                button = mb.exec_()
+                if button == QMessageBox.Abort:
+                    raise RuntimeError('RosPyPluginProvider._init_node() could not find ROS master')
 
     def _init_node(self):
         # initialize node once

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -32,6 +32,7 @@ import os
 import rospy
 
 from qt_gui.composite_plugin_provider import CompositePluginProvider
+from qt_gui.errors import PluginLoadError
 
 from python_qt_binding.QtCore import qDebug, qWarning
 from python_qt_binding.QtGui import QMessageBox
@@ -66,7 +67,7 @@ class RosPyPluginProvider(CompositePluginProvider):
                 mb.setDefaultButton(QMessageBox.Retry)
                 button = mb.exec_()
                 if button == QMessageBox.Abort:
-                    raise RuntimeError('RosPyPluginProvider._init_node() could not find ROS master')
+                    raise PluginLoadError('RosPyPluginProvider._init_node() could not find ROS master')
 
     def _init_node(self):
         # initialize node once


### PR DESCRIPTION
@ablasdel @DorianScholz What is your opinion on this? Is that better that how rqt currently behaves?

I could imagine one related feature: add a modal message box when a plugin start fails to make the message more visible. But that would require to collect the messages of multiple plugins when they are started together (either at start up or via a perspective) to not pop up numerous dialogs.
