### PR TITLE
add ros spinner thread for cpp plugins

### DIFF
--- a/rqt_gui_cpp/package.xml
+++ b/rqt_gui_cpp/package.xml
@@ -14,12 +14,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>qt_gui</build_depend>
-  <build_depend>qt_gui_cpp</build_depend>
+  <build_depend version_gte="0.2.22">qt_gui</build_depend>
+  <build_depend version_gte="0.2.22">qt_gui_cpp</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>nodelet</build_depend>
-  <run_depend>qt_gui</run_depend>
-  <run_depend>qt_gui_cpp</run_depend>
+  <run_depend version_gte="0.2.22">qt_gui</run_depend>
+  <run_depend version_gte="0.2.22">qt_gui_cpp</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>nodelet</run_depend>
   

--- a/rqt_gui_cpp/src/rqt_gui_cpp/nodelet_plugin_provider.h
+++ b/rqt_gui_cpp/src/rqt_gui_cpp/nodelet_plugin_provider.h
@@ -40,6 +40,8 @@
 #include <nodelet/loader.h>
 #include <nodelet/nodelet.h>
 
+#include <QThread>
+
 #include <string>
 
 namespace rqt_gui_cpp {
@@ -58,6 +60,8 @@ public:
 
   virtual void unload(void* instance);
 
+  virtual void shutdown();
+
 protected:
 
   void init_loader();
@@ -73,6 +77,18 @@ protected:
   boost::shared_ptr<rqt_gui_cpp::Plugin> instance_;
 
   QMap<void*, QString> instances_;
+
+  class RosSpinThread
+    : public QThread
+  {
+  public:
+    RosSpinThread(QObject* parent = 0);
+    virtual ~RosSpinThread();
+    void run();
+    bool abort;
+  };
+
+  RosSpinThread* ros_spin_thread_;
 
 };
 


### PR DESCRIPTION
Depends on ros-visualization/qt_gui_core#39.

Enables ros timers etc. by adding a ros spinner thread for cpp plugins (see related question http://answers.ros.org/question/132301/what-am-i-doing-wrong-with-rostimer-in-rqt/).

@DorianScholz Please review.
