### PR TITLE
Created standardized ROS message selector interfaces

### DIFF
--- a/rqt_py_common/src/rqt_py_common/action_combo_box.py
+++ b/rqt_py_common/src/rqt_py_common/action_combo_box.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2011, Dorian Scholz, TU Darmstadt
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#   * Neither the name of the TU Darmstadt nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rospy
+#import rostopic
+from extended_combo_box import ExtendedComboBox
+from python_qt_binding.QtCore import QStringListModel
+
+class ActionComboBox(ExtendedComboBox):
+    def __init__(self, parent=None):
+        super(ActionComboBox, self).__init__(parent)
+        # I attempted to create a timer to update the topic list automatically,
+        # but the timer runs in a different thread and PyQt is not thread-safe.
+        # A ROS node must also be initialized for rospy to function.
+        #self.update_timer = rospy.Timer(rospy.Duration.from_sec(0.5), self.on_update)
+
+    def get_topic_list(self):
+        # TO-DO: Replace with rostopic.get_topic_list() when ros/ros_comm#1154 is merged.
+        # In the meantime this copies code from there.
+        import rosgraph
+        pubs, subs, _ = rosgraph.Master('/rostopic').getSystemState()
+        pubs_out = []
+        for topic, nodes in pubs:
+            pubs_out.append((topic, "", nodes))
+        subs_out = []
+        for topic, nodes in subs:
+            subs_out.append((topic, "", nodes))
+        return (pubs_out, subs_out)
+
+    def update_list(self):
+        pubs, subs = self.get_topic_list()
+        topics = sorted(set([x for x,_,_ in pubs + subs]))
+        # Action filter code from https://github.com/mcgill-robotics/rosaction/blob/master/src/rosaction/__init__.py#L151
+        actions = [x[:-5] for x in topics if x.endswith("goal") and x.replace("/goal", "/cancel") in topics]
+        combo.setModel(QStringListModel(actions))
+
+if __name__ == "__main__":
+    import sys
+    from python_qt_binding.QtWidgets import QApplication
+
+    app = QApplication(sys.argv)
+
+    # Create the combo box itself.
+    combo = ActionComboBox()
+    # Clear the list of topics and pull a new one. Do this on a regular basis, such as when
+    # a user changes an option or clicks a Refresh button.
+    combo.update_list()
+
+    # Make sure your combo box is 
+    combo.resize(600, 40)
+    combo.show()
+
+    sys.exit(app.exec_())

--- a/rqt_py_common/src/rqt_py_common/action_combo_box.py
+++ b/rqt_py_common/src/rqt_py_common/action_combo_box.py
@@ -31,7 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import rospy
-#import rostopic
+import rostopic
 from extended_combo_box import ExtendedComboBox
 from python_qt_binding.QtCore import QStringListModel, QTimer
 
@@ -44,21 +44,8 @@ class ActionComboBox(ExtendedComboBox):
         self.update_timer.timeout.connect(self.update)
         self.update_timer.start()
 
-    def get_topic_list(self):
-        # TO-DO: Replace with rostopic.get_topic_list() when ros/ros_comm#1154 is merged.
-        # In the meantime this copies code from there.
-        import rosgraph
-        pubs, subs, _ = rosgraph.Master('/rostopic').getSystemState()
-        pubs_out = []
-        for topic, nodes in pubs:
-            pubs_out.append((topic, "", nodes))
-        subs_out = []
-        for topic, nodes in subs:
-            subs_out.append((topic, "", nodes))
-        return (pubs_out, subs_out)
-
     def get_action_list(self):
-        pubs, subs = self.get_topic_list()
+        pubs, subs = rostopic.get_topic_list()
         topics = sorted(set([x for x,_,_ in pubs + subs]))
         # Action filter code from https://github.com/mcgill-robotics/rosaction/blob/master/src/rosaction/__init__.py#L151
         return [x[:-5] for x in topics if x.endswith("goal") and x.replace("/goal", "/cancel") in topics]

--- a/rqt_py_common/src/rqt_py_common/extended_combo_box.py
+++ b/rqt_py_common/src/rqt_py_common/extended_combo_box.py
@@ -89,7 +89,7 @@ class ExtendedComboBox(QComboBox):
 
 if __name__ == "__main__":
     import sys
-    from python_qt_binding.QtGui import QApplication
+    from python_qt_binding.QtWidgets import QApplication
 
     app = QApplication(sys.argv)
 

--- a/rqt_py_common/src/rqt_py_common/service_combo_box.py
+++ b/rqt_py_common/src/rqt_py_common/service_combo_box.py
@@ -33,7 +33,7 @@
 import rospy
 import rosservice
 from extended_combo_box import ExtendedComboBox
-from python_qt_binding.QtCore import QStringListModel
+from python_qt_binding.QtCore import QStringListModel, QTimer
 
 class ServiceComboBox(ExtendedComboBox):
     def __init__(self, parent=None, delay=500):

--- a/rqt_py_common/src/rqt_py_common/service_combo_box.py
+++ b/rqt_py_common/src/rqt_py_common/service_combo_box.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2011, Dorian Scholz, TU Darmstadt
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#   * Neither the name of the TU Darmstadt nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rospy
+import rosservice
+from extended_combo_box import ExtendedComboBox
+from python_qt_binding.QtCore import QStringListModel
+
+class ServiceComboBox(ExtendedComboBox):
+    def __init__(self, parent=None):
+        super(ServiceComboBox, self).__init__(parent)
+        # I attempted to create a timer to update the service list automatically,
+        # but the timer runs in a different thread and PyQt is not thread-safe.
+        # A ROS node must also be initialized for rospy to function.
+        #self.update_timer = rospy.Timer(rospy.Duration.from_sec(0.5), self.on_update)
+
+    def update_list(self):
+        combo.setModel(QStringListModel(sorted(set(rosservice.get_service_list()))))
+
+if __name__ == "__main__":
+    import sys
+    from python_qt_binding.QtWidgets import QApplication
+
+    app = QApplication(sys.argv)
+
+    # Create the combo box itself.
+    combo = ServiceComboBox()
+    # Clear the list of services and pull a new one. Do this on a regular basis, such as when
+    # a user changes an option or clicks a Refresh button.
+    combo.update_list()
+
+    # Make sure your combo box is 
+    combo.resize(600, 40)
+    combo.show()
+
+    sys.exit(app.exec_())

--- a/rqt_py_common/src/rqt_py_common/topic_combo_box.py
+++ b/rqt_py_common/src/rqt_py_common/topic_combo_box.py
@@ -31,37 +31,26 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import rospy
-#import rostopic
+import rostopic
 from extended_combo_box import ExtendedComboBox
-from python_qt_binding.QtCore import QStringListModel
+from python_qt_binding.QtCore import QStringListModel, QTimer
 
 class TopicComboBox(ExtendedComboBox):
     def __init__(self, parent=None, delay=500):
         super(TopicComboBox, self).__init__(parent)
-        self.setModel(QStringListModel(self.get_action_list()))
+        self.setModel(QStringListModel(self.get_topic_list()))
         self.update_timer = QTimer()
         self.update_timer.setInterval(delay)
         self.update_timer.timeout.connect(self.update)
         self.update_timer.start()
 
     def get_topic_list(self):
-        # TO-DO: Replace with rostopic.get_topic_list() when ros/ros_comm#1154 is merged.
-        # In the meantime this copies code from there.
-        import rosgraph
-        pubs, subs, _ = rosgraph.Master('/rostopic').getSystemState()
-        pubs_out = []
-        for topic, nodes in pubs:
-            pubs_out.append((topic, "", nodes))
-        subs_out = []
-        for topic, nodes in subs:
-            subs_out.append((topic, "", nodes))
-        return (pubs_out, subs_out)
+        pubs, subs = rostopic.get_topic_list()
+        return sorted(set([x for x,_,_ in pubs] + [x for x,_,_ in subs]))
 
     def update(self):
         currentText = self.currentText()
-        pubs, subs = get_topic_list()
-        topics = sorted(set([x for x,_,_ in pubs] + [x for x,_,_ in subs]))
-        combo.setModel(QStringListModel(topics))
+        combo.setModel(QStringListModel(self.get_topic_list()))
         self.setCurrentText(currentText)
 
 if __name__ == "__main__":

--- a/rqt_py_common/src/rqt_py_common/topic_combo_box.py
+++ b/rqt_py_common/src/rqt_py_common/topic_combo_box.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2011, Dorian Scholz, TU Darmstadt
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#   * Neither the name of the TU Darmstadt nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rospy
+#import rostopic
+from extended_combo_box import ExtendedComboBox
+from python_qt_binding.QtCore import QStringListModel
+
+class TopicComboBox(ExtendedComboBox):
+    def __init__(self, parent=None):
+        super(TopicComboBox, self).__init__(parent)
+        # I attempted to create a timer to update the topic list automatically,
+        # but the timer runs in a different thread and PyQt is not thread-safe.
+        # A ROS node must also be initialized for rospy to function.
+        #self.update_timer = rospy.Timer(rospy.Duration.from_sec(0.5), self.on_update)
+
+    def get_topic_list(self):
+        # TO-DO: Replace with rostopic.get_topic_list() when ros/ros_comm#1154 is merged.
+        # In the meantime this copies code from there.
+        import rosgraph
+        pubs, subs, _ = rosgraph.Master('/rostopic').getSystemState()
+        pubs_out = []
+        for topic, nodes in pubs:
+            pubs_out.append((topic, "", nodes))
+        subs_out = []
+        for topic, nodes in subs:
+            subs_out.append((topic, "", nodes))
+        return (pubs_out, subs_out)
+
+    def update_list(self):
+        pubs, subs = self.get_topic_list()
+        combo.setModel(QStringListModel(sorted(set([x for x,_,_ in pubs] + [x for x,_,_ in subs]))))
+
+if __name__ == "__main__":
+    import sys
+    from python_qt_binding.QtWidgets import QApplication
+
+    app = QApplication(sys.argv)
+
+    # Create the combo box itself.
+    combo = TopicComboBox()
+    # Clear the list of topics and pull a new one. Do this on a regular basis, such as when
+    # a user changes an option or clicks a Refresh button.
+    combo.update_list()
+
+    # Make sure your combo box is 
+    combo.resize(600, 40)
+    combo.show()
+
+    sys.exit(app.exec_())


### PR DESCRIPTION
Resolves issue #119.

Adds 3 new Qt widgets; `TopicComboBox`, `ServiceComboBox`, and `ActionComboBox`. Their models are set to be the list of topics, services, and actions, respectively.

Several side notes on this commit:
- This also fixes a bug in `extended_combo_box.py` that prevented the widget from functioning.
- There is currently no filter on what topics are displayed; do we want to add one or more filters? A regex filter for the topic name? A filter on what topic types are allowed?
- There is an issue with how PyQt is designed; it only allows modification of GUI elements from the main thread. I was initially going to implement a `rospy.Timer` to automatically update the list, but updating the list from the timer thread crashes the program. The current solution requires the application implementing the widget to run `TopicComboBox.update_list()` on some regular basis (such as when a refresh button is clicked) from the main GUI thread. If there is a better solution to this problem that puts less work on the implementors, please tell me.
- `TopicComboBox` and `ActionComboBox` currently use a hardcoded `get_topic_list()` method to get the list of topics; when ros/ros_comm#1154 is merged and `rostopic` has a public method for this, it should be removed.