### PR TITLE
Porting rqt_gui to ros2

### DIFF
--- a/rqt_gui/CMakeLists.txt
+++ b/rqt_gui/CMakeLists.txt
@@ -1,13 +1,18 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(rqt_gui)
+
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS qt_gui)
-catkin_package()
-catkin_python_setup()
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME}
+  PACKAGE_DIR src/${PROJECT_NAME})
 
 install(PROGRAMS bin/rqt_gui
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  DESTINATION bin
 )
-install(FILES resource/rqt.png
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resource
+install(DIRECTORY resource
+  DESTINATION share
 )
+
+ament_package()

--- a/rqt_gui/bin/rqt
+++ b/rqt_gui/bin/rqt
@@ -1,13 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys
 
-import rospkg
-r = rospkg.RosPack()
-p = r.get_path('rqt_gui')
-sys.path.append(os.path.join(p, 'src'))
-
 from rqt_gui.main import Main
-main = Main(filename=os.path.abspath(__file__), ros_pack=r)
+main = Main(filename=os.path.abspath(__file__))
 sys.exit(main.main())

--- a/rqt_gui/bin/rqt_gui
+++ b/rqt_gui/bin/rqt_gui
@@ -1,13 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys
 
-import rospkg
-r = rospkg.RosPack()
-p = r.get_path('rqt_gui')
-sys.path.append(os.path.join(p, 'src'))
-
 from rqt_gui.main import Main
-main = Main(filename=os.path.abspath(__file__), ros_pack=r)
+main = Main(filename=os.path.abspath(__file__))
 sys.exit(main.main())

--- a/rqt_gui/package.xml
+++ b/rqt_gui/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>rqt_gui</name>
   <version>0.5.0</version>
   <description>rqt_gui provides the main to start an instance of the ROS integrated graphical user interface provided by qt_gui.</description>
@@ -12,9 +12,18 @@
 
   <author>Dirk Thomas</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
-  <run_depend>catkin</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui</run_depend>
+
+  <exec_depend>ament_cmake_python</exec_depend>
+  <exec_depend>python_qt_binding</exec_depend>
+  <exec_depend>python3-catkin-pkg-modules</exec_depend>
+  <exec_depend>qt_gui</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/rqt_gui/setup.py
+++ b/rqt_gui/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
+
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/rqt_gui/setup.py
+++ b/rqt_gui/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.core import setup
 
@@ -7,7 +7,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 package_name = "rqt_gui"
 
 d = generate_distutils_setup(
-    packages=['rqt_gui'],
+    packages=[package_name],
     package_dir={'': 'src'},
     scripts=['bin/rqt'],
     data_files=[

--- a/rqt_gui/setup.py
+++ b/rqt_gui/setup.py
@@ -6,7 +6,12 @@ from catkin_pkg.python_setup import generate_distutils_setup
 d = generate_distutils_setup(
     packages=['rqt_gui'],
     package_dir={'': 'src'},
-    scripts=['bin/rqt']
+    scripts=['bin/rqt'],
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
 )
 
 setup(**d)

--- a/rqt_gui/setup.py
+++ b/rqt_gui/setup.py
@@ -4,6 +4,8 @@ from distutils.core import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 
+package_name = "rqt_gui"
+
 d = generate_distutils_setup(
     packages=['rqt_gui'],
     package_dir={'': 'src'},

--- a/rqt_gui/src/rqt_gui/main.py
+++ b/rqt_gui/src/rqt_gui/main.py
@@ -51,7 +51,8 @@ class Main(Base):
             argv = sys.argv
 
         # ignore ROS specific remapping arguments
-        # TODO port to ros2
+        # TODO(brawner) port to ros2. Waiting on a feature add and PR on rclpy
+	# to expose this functionality
         # argv = rclpy.parse_arguments(argv)
 
         return super(

--- a/rqt_gui/src/rqt_gui/main.py
+++ b/rqt_gui/src/rqt_gui/main.py
@@ -35,8 +35,6 @@
 import os
 import sys
 
-import rclpy
-
 from qt_gui.main import Main as Base
 from qt_gui.ros_package_helper import get_package_path
 

--- a/rqt_gui/src/rqt_gui/main.py
+++ b/rqt_gui/src/rqt_gui/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Software License Agreement (BSD License)
 #
@@ -35,37 +35,35 @@
 import os
 import sys
 
-import rospy
-from rospkg.rospack import RosPack
+import rclpy
 
 from qt_gui.main import Main as Base
+from qt_gui.ros_package_helper import get_package_path
 
 
 class Main(Base):
 
-    def __init__(self, filename=None, ros_pack=None):
-        rp = ros_pack or RosPack()
-        qtgui_path = rp.get_path('qt_gui')
+    def __init__(self, filename=None):
+        qtgui_path = get_package_path('qt_gui')
         super(Main, self).__init__(
             qtgui_path, invoked_filename=filename, settings_filename='rqt_gui')
-        self._ros_pack = rp
 
     def main(self, argv=None, standalone=None, plugin_argument_provider=None):
         if argv is None:
             argv = sys.argv
 
-        # ignore ROS specific remapping arguments (see
-        # http://www.ros.org/wiki/Remapping%20Arguments)
-        argv = rospy.myargv(argv)
+        # ignore ROS specific remapping arguments
+        # TODO port to ros2
+        # argv = rclpy.parse_arguments(argv)
 
         return super(
-            Main, self).main(argv, standalone=standalone, plugin_argument_provider=plugin_argument_provider,
-                             plugin_manager_settings_prefix=str(hash(os.environ['ROS_PACKAGE_PATH'])))
+            Main, self).main(argv, standalone=standalone, plugin_argument_provider=plugin_argument_provider)
 
     def create_application(self, argv):
         from python_qt_binding.QtGui import QIcon
         app = super(Main, self).create_application(argv)
-        logo = os.path.join(self._ros_pack.get_path('rqt_gui'), 'resource', 'rqt.png')
+        rqt_gui_path = get_package_path('rqt_gui')
+        logo = os.path.join(rqt_gui_path, 'share', 'resource', 'rqt.png')
         icon = QIcon(logo)
         app.setWindowIcon(icon)
         return app
@@ -74,8 +72,7 @@ class Main(Base):
         # do not import earlier as it would import Qt stuff without the proper
         # initialization from qt_gui.main
         from qt_gui.recursive_plugin_provider import RecursivePluginProvider
-        from .rospkg_plugin_provider import RospkgPluginProvider
-        RospkgPluginProvider.rospack = self._ros_pack
+        from rqt_gui.rospkg_plugin_provider import RospkgPluginProvider
         self.plugin_providers.append(RospkgPluginProvider('qt_gui', 'qt_gui_py::Plugin'))
         self.plugin_providers.append(RecursivePluginProvider(
             RospkgPluginProvider('qt_gui', 'qt_gui_py::PluginProvider')))

--- a/rqt_gui/src/rqt_gui/main.py
+++ b/rqt_gui/src/rqt_gui/main.py
@@ -35,10 +35,10 @@
 import os
 import sys
 
-import rospy
-from rospkg.rospack import RosPack
-
 from qt_gui.main import Main as Base
+
+from rospkg.rospack import RosPack
+import rospy
 
 
 class Main(Base):
@@ -59,8 +59,10 @@ class Main(Base):
         argv = rospy.myargv(argv)
 
         return super(
-            Main, self).main(argv, standalone=standalone, plugin_argument_provider=plugin_argument_provider,
-                             plugin_manager_settings_prefix=str(hash(os.environ['ROS_PACKAGE_PATH'])))
+            Main, self).main(argv, standalone=standalone,
+                             plugin_argument_provider=plugin_argument_provider,
+                             plugin_manager_settings_prefix=str(
+                                hash(os.environ['ROS_PACKAGE_PATH'])))
 
     def create_application(self, argv):
         from python_qt_binding.QtGui import QIcon

--- a/rqt_gui/src/rqt_gui/ros_plugin_provider.py
+++ b/rqt_gui/src/rqt_gui/ros_plugin_provider.py
@@ -84,8 +84,9 @@ class RosPluginProvider(PluginProvider):
         except Exception as e:
             qCritical('RosPluginProvider.load(%s) exception raised in '
                       '__builtin__.__import__(%s, [%s]):\n%s' % (
-                       plugin_id, attributes['module_name'], attributes['class_from_class_type'],
-                       traceback.format_exc()))
+                          plugin_id, attributes['module_name'],
+                          attributes['class_from_class_type'],
+                          traceback.format_exc()))
             raise e
 
         class_ref = getattr(module, attributes['class_from_class_type'], None)

--- a/rqt_gui/src/rqt_gui/ros_plugin_provider.py
+++ b/rqt_gui/src/rqt_gui/ros_plugin_provider.py
@@ -41,11 +41,9 @@ from python_qt_binding.QtCore import qCritical
 
 from qt_gui.plugin_descriptor import PluginDescriptor
 from qt_gui.plugin_provider import PluginProvider
-from qt_gui.ros_package_helper import get_package_path
 
 
 class RosPluginProvider(PluginProvider):
-
     """Base class for providing plugins based on the ROS package system."""
 
     def __init__(self, export_tag, base_class_type):
@@ -59,6 +57,7 @@ class RosPluginProvider(PluginProvider):
     def discover(self, discovery_data):
         """
         Discover the plugins.
+
         The information of the `PluginDescriptor`s are extracted from the plugin manifests.
         """
         # search for plugins
@@ -83,8 +82,10 @@ class RosPluginProvider(PluginProvider):
             qCritical('RosPluginProvider.load(%s): raised an exception:\n%s' % (plugin_id, e))
             return None
         except Exception as e:
-            qCritical('RosPluginProvider.load(%s) exception raised in __builtin__.__import__(%s, [%s]):\n%s' % (
-                plugin_id, attributes['module_name'], attributes['class_from_class_type'], traceback.format_exc()))
+            qCritical('RosPluginProvider.load(%s) exception raised in '
+                      '__builtin__.__import__(%s, [%s]):\n%s' % (
+                       plugin_id, attributes['module_name'], attributes['class_from_class_type'],
+                       traceback.format_exc()))
             raise e
 
         class_ref = getattr(module, attributes['class_from_class_type'], None)
@@ -113,15 +114,15 @@ class RosPluginProvider(PluginProvider):
         plugin_descriptors = []
 
         if not os.path.isfile(plugin_xml):
-            qCritical('RosPluginProvider._parse_plugin_xml() plugin file "%s" in package "%s" not found' %
-                      (plugin_xml, package_name))
+            qCritical('RosPluginProvider._parse_plugin_xml() plugin file "%s" in package "%s" '
+                      'not found' % (plugin_xml, package_name))
             return plugin_descriptors
 
         try:
             root = ElementTree.parse(plugin_xml)
         except Exception:
-            qCritical('RosPluginProvider._parse_plugin_xml() could not parse "%s" in package "%s"' %
-                      (plugin_xml, package_name))
+            qCritical('RosPluginProvider._parse_plugin_xml() could not parse "%s" in package "%s"'
+                      % (plugin_xml, package_name))
             return plugin_descriptors
         for library_el in root.getiterator('library'):
             library_path = library_el.attrib['path']


### PR DESCRIPTION
This ports the rqt_gui package from rqt. For the most part it changes rospack logic to ament_index logic and creates an ament package.

There is one todo added here, which requires parsing any arguments with ros logic. Before this was handled with rospy, but there doesn't appear to be a specific hook with rclpy yet.

This also incorporates the style changes in #143. So for comparison sake that one might need to be merged first.