### PR TITLE
Porting rqt_gui_py to ROS2 with testing

### DIFF
--- a/rqt_gui_py/CMakeLists.txt
+++ b/rqt_gui_py/CMakeLists.txt
@@ -1,10 +1,14 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(rqt_gui_py)
-# Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS rqt_gui rospy)
-catkin_package()
-catkin_python_setup()
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME}
+  PACKAGE_DIR src/${PROJECT_NAME})
 
 install(FILES plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  DESTINATION share/${PROJECT_NAME}
 )
+
+ament_package()

--- a/rqt_gui_py/CMakeLists.txt
+++ b/rqt_gui_py/CMakeLists.txt
@@ -11,4 +11,14 @@ install(FILES plugin.xml
   DESTINATION share/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_pytest_test(${PROJECT_NAME} test
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 90)
+endif()
+
 ament_package()

--- a/rqt_gui_py/package.xml
+++ b/rqt_gui_py/package.xml
@@ -20,6 +20,12 @@
   <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
   <exec_depend version_gte="0.3.0">rqt_gui</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
     <build_type>ament_cmake</build_type>

--- a/rqt_gui_py/package.xml
+++ b/rqt_gui_py/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>rqt_gui_py</name>
   <version>0.5.0</version>
   <description>rqt_gui_py enables GUI plugins to use the Python client library for ROS.</description>
@@ -12,17 +12,16 @@
 
   <author>Dirk Thomas</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
   <build_depend version_gte="0.3.0">rqt_gui</build_depend>
-  <build_depend>rospy</build_depend>
 
-  <run_depend version_gte="0.3.0">qt_gui</run_depend>
-  <run_depend version_gte="0.3.0">rqt_gui</run_depend>
-  <run_depend>rospy</run_depend>
-  
+  <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
+  <exec_depend version_gte="0.3.0">rqt_gui</exec_depend>
+
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/rqt_gui_py/setup.py
+++ b/rqt_gui_py/setup.py
@@ -3,9 +3,16 @@
 from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
+package_name = 'rqt_gui_py'
+
 d = generate_distutils_setup(
     packages=['rqt_gui_py'],
-    package_dir={'': 'src'}
+    package_dir={'': 'src'},
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
 )
 
 setup(**d)

--- a/rqt_gui_py/setup.py
+++ b/rqt_gui_py/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
+
 from catkin_pkg.python_setup import generate_distutils_setup
 
 package_name = 'rqt_gui_py'

--- a/rqt_gui_py/src/rqt_gui_py/plugin.py
+++ b/rqt_gui_py/src/rqt_gui_py/plugin.py
@@ -34,12 +34,13 @@ from qt_gui.plugin import Plugin as Base
 
 
 class Plugin(Base):
-
     """
     Interface for Python plugins which use the ROS client library.
-    User-defined plugins may either subclass `rqt_gui_py.plugin.Plugin` or according to duck typing implement only the needed methods.
-    A plugin must not call rospy.init_node() as this is performed once by the framework.
-    The name of the ROS node consists of the prefix "rqt_gui_py_node_" and the process id.
+
+    User-defined plugins may either subclass `rqt_gui_py.plugin.Plugin` or according to duck typing
+    implement only the needed methods. A plugin must not call rospy.init_node() as this is
+    performed once by the framework. The name of the ROS node consists of the prefix
+    "rqt_gui_py_node_" and the process id.
     """
 
     def __init__(self, context):
@@ -48,6 +49,7 @@ class Plugin(Base):
     def shutdown_plugin(self):
         """
         Shutdown and clean up the plugin before unloading.
+
         I.e. unregister subscribers and stop timers.
         """
         pass

--- a/rqt_gui_py/src/rqt_gui_py/plugin.py
+++ b/rqt_gui_py/src/rqt_gui_py/plugin.py
@@ -38,7 +38,7 @@ class Plugin(Base):
     Interface for Python plugins which use the ROS client library.
 
     User-defined plugins may either subclass `rqt_gui_py.plugin.Plugin` or according to duck typing
-    implement only the needed methods. A plugin must not call rospy.init_node() as this is
+    implement only the needed methods. A plugin must not call rclpy.create_node() as this is
     performed once by the framework. The name of the ROS node consists of the prefix
     "rqt_gui_py_node_" and the process id.
     """

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -29,23 +29,15 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import os
-import threading
-import time
+
+from python_qt_binding.QtCore import qDebug
+from qt_gui.composite_plugin_provider import CompositePluginProvider
 
 import rclpy
-
-from qt_gui.composite_plugin_provider import CompositePluginProvider
-from qt_gui.errors import PluginLoadError
-
-from python_qt_binding.QtCore import qDebug, Qt, qWarning, Signal
-from python_qt_binding.QtWidgets import QMessageBox
-
 from rqt_gui.rospkg_plugin_provider import RospkgPluginProvider
 
 
 class RosPyPluginProvider(CompositePluginProvider):
-
-    _master_found_signal = Signal(int)
 
     def __init__(self):
         super(RosPyPluginProvider, self).__init__(

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -50,6 +50,10 @@ class RosPyPluginProvider(CompositePluginProvider):
         self._init_node()
         return super(RosPyPluginProvider, self).load(plugin_id, plugin_context)
 
+    def unload(self, plugin_instance):
+        self._destroy_node()
+        return super(RosPyPluginProvider, self).unload(plugin_instance)
+
     def _init_node(self):
         # initialize node once
         if not self._node_initialized:
@@ -58,3 +62,9 @@ class RosPyPluginProvider(CompositePluginProvider):
             rclpy.init()
             self._node = rclpy.create_node(name)
             self._node_initialized = True
+
+    def _destroy_node(self):
+        if self._node_initialized:
+            self._node.destroy_node()
+            rclpy.shutdown()
+            self._node_initialized = False

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -32,7 +32,7 @@ import os
 import threading
 import time
 
-import rospy
+import rclpy
 
 from qt_gui.composite_plugin_provider import CompositePluginProvider
 from qt_gui.errors import PluginLoadError
@@ -52,54 +52,18 @@ class RosPyPluginProvider(CompositePluginProvider):
             [RospkgPluginProvider('rqt_gui', 'rqt_gui_py::Plugin')])
         self.setObjectName('RosPyPluginProvider')
         self._node_initialized = False
-        self._wait_for_master_dialog = None
-        self._wait_for_master_thread = None
+        self._node = None
 
     def load(self, plugin_id, plugin_context):
-        self._check_for_master()
         self._init_node()
         return super(RosPyPluginProvider, self).load(plugin_id, plugin_context)
-
-    def _check_for_master(self):
-        # check if master is available
-        try:
-            rospy.get_master().getSystemState()
-            return
-        except Exception:
-            pass
-        # spawn thread to detect when master becomes available
-        self._wait_for_master_thread = threading.Thread(target=self._wait_for_master)
-        self._wait_for_master_thread.start()
-        self._wait_for_master_dialog = QMessageBox(QMessageBox.Question,
-                                                   self.tr('Waiting for ROS master'),
-                                                   self.tr("Could not find ROS master. Either start a 'roscore' or "
-                                                           "abort loading the plugin."),
-                                                   QMessageBox.Abort)
-        self._master_found_signal.connect(self._wait_for_master_dialog.done, Qt.QueuedConnection)
-        button = self._wait_for_master_dialog.exec_()
-        # check if master existence was not detected by background thread
-        no_master = button != QMessageBox.Ok
-        self._wait_for_master_dialog.deleteLater()
-        self._wait_for_master_dialog = None
-        if no_master:
-            raise PluginLoadError('RosPyPluginProvider._init_node() could not find ROS master')
-
-    def _wait_for_master(self):
-        while True:
-            time.sleep(0.1)
-            if not self._wait_for_master_dialog:
-                break
-            try:
-                rospy.get_master().getSystemState()
-            except Exception:
-                continue
-            self._master_found_signal.emit(QMessageBox.Ok)
-            break
 
     def _init_node(self):
         # initialize node once
         if not self._node_initialized:
             name = 'rqt_gui_py_node_%d' % os.getpid()
             qDebug('RosPyPluginProvider._init_node() initialize ROS node "%s"' % name)
-            rospy.init_node(name, disable_signals=True)
+            rclpy.init()
+            self._node = rclpy.create_node(name)
+            # rospy.init_node(name, disable_signals=True)
             self._node_initialized = True

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -57,5 +57,4 @@ class RosPyPluginProvider(CompositePluginProvider):
             qDebug('RosPyPluginProvider._init_node() initialize ROS node "%s"' % name)
             rclpy.init()
             self._node = rclpy.create_node(name)
-            # rospy.init_node(name, disable_signals=True)
             self._node_initialized = True

--- a/rqt_gui_py/test/test_flake8.py
+++ b/rqt_gui_py/test/test_flake8.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'

--- a/rqt_gui_py/test/test_pep257.py
+++ b/rqt_gui_py/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
This ports the package rqt_gui_py to ROS2 with flake8 testing included. 

Passing CI build https://ci.ros2.org/job/ci_linux/5458