### PR TITLE
Updating rqt_gui CMakeLists to properly install rqt_gui executable

### DIFF
--- a/rqt_gui/CMakeLists.txt
+++ b/rqt_gui/CMakeLists.txt
@@ -9,7 +9,7 @@ ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR src/${PROJECT_NAME})
 
 install(PROGRAMS bin/rqt_gui
-  DESTINATION bin
+  DESTINATION lib/${PROJECT_NAME}
 )
 install(DIRECTORY resource
   DESTINATION share


### PR DESCRIPTION
This moves the rqt_gui python executable to the lib directory, where it can be found as an executable.