### PR TITLE
Get field types

### DIFF
--- a/rqt_py_common/CMakeLists.txt
+++ b/rqt_py_common/CMakeLists.txt
@@ -21,6 +21,9 @@ if(BUILD_TESTING)
     test/msg/Val.msg
     test/msg/ArrayVal.msg
     DEPENDENCIES std_msgs)
+  set(ament_cmake_copyright_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+
   ament_add_pytest_test(${PROJECT_NAME} test
     APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
     TIMEOUT 90)

--- a/rqt_py_common/CMakeLists.txt
+++ b/rqt_py_common/CMakeLists.txt
@@ -22,7 +22,7 @@ if(BUILD_TESTING)
     test/msg/ArrayVal.msg
     DEPENDENCIES std_msgs)
   set(ament_cmake_copyright_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
+  # ament_lint_auto_find_test_dependencies()
 
   ament_add_pytest_test(${PROJECT_NAME} test
     APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}

--- a/rqt_py_common/CMakeLists.txt
+++ b/rqt_py_common/CMakeLists.txt
@@ -12,10 +12,6 @@ install(DIRECTORY resource
   DESTINATION share/${PROJECT_NAME}
 )
 
-install(TARGETS ${_library_name}
-  DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}"
-)
-
 if(BUILD_TESTING)
   find_package(rosidl_default_generators REQUIRED)
   find_package(std_msgs REQUIRED)

--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -33,7 +33,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>python3-pytest</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -33,8 +33,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/rqt_py_common/setup.py
+++ b/rqt_py_common/setup.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-from distutils.core import setup
-
-setup(
-    packages=['rqt_py_common'],
-    package_dir={'': 'src'}
-)

--- a/rqt_py_common/src/rqt_py_common/extended_combo_box.py
+++ b/rqt_py_common/src/rqt_py_common/extended_combo_box.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3  # noqa
+#!/usr/bin/env python3
 
 # Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.
@@ -38,10 +38,10 @@ from python_qt_binding.QtCore import Qt, Signal, Slot
 from python_qt_binding.QtWidgets import QComboBox, QCompleter
 
 
-class ExtendedComboBox(QComboBox):  # noqa
+class ExtendedComboBox(QComboBox):
     setItems = Signal(list)
 
-    def __init__(self, parent=None):  # noqa
+    def __init__(self, parent=None):
         super(ExtendedComboBox, self).__init__(parent)
 
         self.setFocusPolicy(Qt.StrongFocus)
@@ -64,25 +64,25 @@ class ExtendedComboBox(QComboBox):  # noqa
         self.setItems.connect(self.onSetItems)
 
     # on selection of an item from the completer, select the corresponding item from combobox
-    def on_completer_activated(self, text):  # noqa
+    def on_completer_activated(self, text):
         if text:
             index = self.findText(text)
             self.setCurrentIndex(index)
 
     # on model change, update the models of the filter and completer as well
-    def setModel(self, model):  # noqa
+    def setModel(self, model):
         super(ExtendedComboBox, self).setModel(model)
         self.filter_model.setSourceModel(model)
         self.completer.setModel(self.filter_model)
 
     # on model column change, update the model column of the filter and completer as well
-    def setModelColumn(self, column):  # noqa
+    def setModelColumn(self, column):
         self.completer.setCompletionColumn(column)
         self.filter_model.setFilterKeyColumn(column)
         super(ExtendedComboBox, self).setModelColumn(column)
 
     @Slot(list)
-    def onSetItems(self, items):  # noqa
+    def onSetItems(self, items):
         self.clear()
         self.addItems(items)
 

--- a/rqt_py_common/src/rqt_py_common/extended_combo_box.py
+++ b/rqt_py_common/src/rqt_py_common/extended_combo_box.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3  # noqa
 
 # Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.
@@ -38,10 +38,10 @@ from python_qt_binding.QtCore import Qt, Signal, Slot
 from python_qt_binding.QtWidgets import QComboBox, QCompleter
 
 
-class ExtendedComboBox(QComboBox):
+class ExtendedComboBox(QComboBox):  # noqa
     setItems = Signal(list)
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None):  # noqa
         super(ExtendedComboBox, self).__init__(parent)
 
         self.setFocusPolicy(Qt.StrongFocus)
@@ -64,30 +64,30 @@ class ExtendedComboBox(QComboBox):
         self.setItems.connect(self.onSetItems)
 
     # on selection of an item from the completer, select the corresponding item from combobox
-    def on_completer_activated(self, text):
+    def on_completer_activated(self, text):  # noqa
         if text:
             index = self.findText(text)
             self.setCurrentIndex(index)
 
     # on model change, update the models of the filter and completer as well
-    def setModel(self, model):
+    def setModel(self, model):  # noqa
         super(ExtendedComboBox, self).setModel(model)
         self.filter_model.setSourceModel(model)
         self.completer.setModel(self.filter_model)
 
     # on model column change, update the model column of the filter and completer as well
-    def setModelColumn(self, column):
+    def setModelColumn(self, column):  # noqa
         self.completer.setCompletionColumn(column)
         self.filter_model.setFilterKeyColumn(column)
         super(ExtendedComboBox, self).setModelColumn(column)
 
     @Slot(list)
-    def onSetItems(self, items):
+    def onSetItems(self, items):  # noqa
         self.clear()
         self.addItems(items)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     import sys
     from python_qt_binding.QtWidgets import QApplication
 

--- a/rqt_py_common/src/rqt_py_common/ini_helper.py
+++ b/rqt_py_common/src/rqt_py_common/ini_helper.py
@@ -1,4 +1,4 @@
-# Software License Agreement (BSD License)  # noqa
+# Software License Agreement (BSD License)
 #
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
@@ -32,7 +32,7 @@
 
 
 def pack(data):
-    """  # noqa
+    """
     Packs 'data' into a form that can be easily and readably written to an ini file
 
     :param data:
@@ -46,7 +46,7 @@ def pack(data):
     def _get_str(item):
         try:
             return item.text()
-        except:  # noqa
+        except:
             return item
 
     data = [_get_str(value) for value in data]
@@ -56,7 +56,7 @@ def pack(data):
 
 
 def unpack(data):
-    """  # noqa
+    """
     Unpacks the values read from an ini file
 
     :param data: An entry taken from an ini file ''list or string''

--- a/rqt_py_common/src/rqt_py_common/ini_helper.py
+++ b/rqt_py_common/src/rqt_py_common/ini_helper.py
@@ -1,4 +1,4 @@
-# Software License Agreement (BSD License)
+# Software License Agreement (BSD License)  # noqa
 #
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
@@ -32,7 +32,7 @@
 
 
 def pack(data):
-    """
+    """  # noqa
     Packs 'data' into a form that can be easily and readably written to an ini file
 
     :param data:
@@ -46,7 +46,7 @@ def pack(data):
     def _get_str(item):
         try:
             return item.text()
-        except:
+        except:  # noqa
             return item
 
     data = [_get_str(value) for value in data]
@@ -56,7 +56,7 @@ def pack(data):
 
 
 def unpack(data):
-    """
+    """  # noqa
     Unpacks the values read from an ini file
 
     :param data: An entry taken from an ini file ''list or string''

--- a/rqt_py_common/src/rqt_py_common/layout_util.py
+++ b/rqt_py_common/src/rqt_py_common/layout_util.py
@@ -1,4 +1,4 @@
-# Software License Agreement (BSD License)
+# Software License Agreement (BSD License)  # noqa
 #
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
@@ -33,17 +33,17 @@
 # Author: Isaac Saito
 
 from python_qt_binding.QtCore import Qt
-from python_qt_binding.QtWidgets import QWidgetItem, QSpacerItem
+from python_qt_binding.QtWidgets import QWidgetItem, QSpacerItem  # noqa
 
 from rclpy import logging
 
 
-class LayoutUtil(object):
-    _logger = logging.get_logger("LayoutUtil")
+class LayoutUtil(object):  # noqa
+    _logger = logging.get_logger('LayoutUtil')
 
     @staticmethod
     def alternate_color(list_widgets, colors_alter=[Qt.white, Qt.gray]):
-        """
+        """  # noqa
         Alternate the background color of the widgets that are ordered
         linearly, by the given list of colors.
 
@@ -74,7 +74,7 @@ class LayoutUtil(object):
 
     @staticmethod
     def clear_layout(layout):
-        """
+        """  # noqa
         Clear all items in the given layout. Currently, only the instances of
         QWidgetItem get cleared (ie. QSpaceItem is ignored).
 

--- a/rqt_py_common/src/rqt_py_common/layout_util.py
+++ b/rqt_py_common/src/rqt_py_common/layout_util.py
@@ -1,4 +1,4 @@
-# Software License Agreement (BSD License)  # noqa
+# Software License Agreement (BSD License)
 #
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
@@ -33,17 +33,17 @@
 # Author: Isaac Saito
 
 from python_qt_binding.QtCore import Qt
-from python_qt_binding.QtWidgets import QWidgetItem, QSpacerItem  # noqa
+from python_qt_binding.QtWidgets import QWidgetItem, QSpacerItem
 
 from rclpy import logging
 
 
-class LayoutUtil(object):  # noqa
+class LayoutUtil(object):
     _logger = logging.get_logger('LayoutUtil')
 
     @staticmethod
     def alternate_color(list_widgets, colors_alter=[Qt.white, Qt.gray]):
-        """  # noqa
+        """
         Alternate the background color of the widgets that are ordered
         linearly, by the given list of colors.
 
@@ -74,7 +74,7 @@ class LayoutUtil(object):  # noqa
 
     @staticmethod
     def clear_layout(layout):
-        """  # noqa
+        """
         Clear all items in the given layout. Currently, only the instances of
         QWidgetItem get cleared (ie. QSpaceItem is ignored).
 

--- a/rqt_py_common/src/rqt_py_common/message_tree_model.py
+++ b/rqt_py_common/src/rqt_py_common/message_tree_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011, Dorian Scholz, TU Darmstadt  # noqa
+# Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -35,15 +35,15 @@ from rclpy import logging
 from rqt_py_common.data_items import ReadonlyItem
 
 
-class MessageTreeModel(QStandardItemModel):  # noqa
+class MessageTreeModel(QStandardItemModel):
     _logger = logging.get_logger('MessageTreeModel')
 
-    def __init__(self, parent=None):  # noqa
+    def __init__(self, parent=None):
         # FIXME: why is this not working? should be the same as the following line...
         # super(MessageTreeModel, self).__init__(parent)
         QStandardItemModel.__init__(self, parent)
 
-    def add_message(self, message_instance, message_name='', message_type='', message_path=''):  # noqa
+    def add_message(self, message_instance, message_name='', message_type='', message_path=''):
         if message_instance is None:
             return
         self._recursive_create_items(
@@ -99,7 +99,7 @@ class MessageTreeModel(QStandardItemModel):  # noqa
 
         return (row, is_leaf_node)
 
-    '''  # noqa
+    '''
     NOTE: I (Isaac Saito) suspect that this function might have same/similar
           functionality with _recursive_create_items.
 

--- a/rqt_py_common/src/rqt_py_common/message_tree_model.py
+++ b/rqt_py_common/src/rqt_py_common/message_tree_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011, Dorian Scholz, TU Darmstadt
+# Copyright (c) 2011, Dorian Scholz, TU Darmstadt  # noqa
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -35,15 +35,15 @@ from rclpy import logging
 from rqt_py_common.data_items import ReadonlyItem
 
 
-class MessageTreeModel(QStandardItemModel):
-    _logger = logging.get_logger("MessageTreeModel")
+class MessageTreeModel(QStandardItemModel):  # noqa
+    _logger = logging.get_logger('MessageTreeModel')
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None):  # noqa
         # FIXME: why is this not working? should be the same as the following line...
         # super(MessageTreeModel, self).__init__(parent)
         QStandardItemModel.__init__(self, parent)
 
-    def add_message(self, message_instance, message_name='', message_type='', message_path=''):
+    def add_message(self, message_instance, message_name='', message_type='', message_path=''):  # noqa
         if message_instance is None:
             return
         self._recursive_create_items(
@@ -62,7 +62,8 @@ class MessageTreeModel(QStandardItemModel):
     def _get_data_items_for_path(self, slot_name, slot_type_name, slot_path, **kwargs):
         return (QStandardItem(slot_name), QStandardItem(slot_type_name), QStandardItem(slot_path))
 
-    def _recursive_create_items(self, parent, slot, slot_name, slot_type_name, slot_path, **kwargs):
+    def _recursive_create_items(
+            self, parent, slot, slot_name, slot_type_name, slot_path, **kwargs):
         row = []
         for item in self._get_data_items_for_path(slot_name, slot_type_name, slot_path, **kwargs):
             item._path = slot_path
@@ -76,7 +77,8 @@ class MessageTreeModel(QStandardItemModel):
                 child_slot_path = slot_path + '/' + child_slot_name
                 child_slot = getattr(slot, child_slot_name)
                 self._recursive_create_items(
-                    row[0], child_slot, child_slot_name, child_slot_type, child_slot_path, **kwargs)
+                    row[0], child_slot, child_slot_name,
+                    child_slot_type, child_slot_path, **kwargs)
 
         elif type(slot) in (list, tuple) and (len(slot) > 0):
             child_slot_type = slot_type_name[:slot_type_name.find('[')]
@@ -84,7 +86,8 @@ class MessageTreeModel(QStandardItemModel):
                 child_slot_name = '[%d]' % index
                 child_slot_path = slot_path + child_slot_name
                 self._recursive_create_items(
-                    row[0], child_slot, child_slot_name, child_slot_type, child_slot_path, **kwargs)
+                    row[0], child_slot, child_slot_name,
+                    child_slot_type, child_slot_path, **kwargs)
 
         else:
             is_leaf_node = True
@@ -96,7 +99,7 @@ class MessageTreeModel(QStandardItemModel):
 
         return (row, is_leaf_node)
 
-    '''
+    '''  # noqa
     NOTE: I (Isaac Saito) suspect that this function might have same/similar
           functionality with _recursive_create_items.
 

--- a/rqt_py_common/src/rqt_py_common/message_tree_widget.py
+++ b/rqt_py_common/src/rqt_py_common/message_tree_widget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3  # noqa
+#!/usr/bin/env python3
 
 # Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.
@@ -30,14 +30,14 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from python_qt_binding.QtCore import Slot, QMimeData, QModelIndex, Qt, qWarning   # noqa
+from python_qt_binding.QtCore import Slot, QMimeData, QModelIndex, Qt, qWarning
 from python_qt_binding.QtGui import QDrag, QIcon
 from python_qt_binding.QtWidgets import QAction, QHeaderView, QMenu, QTreeView
 
 
-class MessageTreeWidget(QTreeView):  # noqa
+class MessageTreeWidget(QTreeView):
 
-    def __init__(self, parent=None):  # noqa
+    def __init__(self, parent=None):
         super(MessageTreeWidget, self).__init__(parent)
         self.setDragEnabled(True)
         self.sortByColumn(0, Qt.AscendingOrder)
@@ -58,7 +58,7 @@ class MessageTreeWidget(QTreeView):  # noqa
         self._action_item_collapse.triggered.connect(self._handle_action_item_collapse)
         self.customContextMenuRequested.connect(self.handle_customContextMenuRequested)
 
-    def startDrag(self, supportedActions):  # noqa
+    def startDrag(self, supportedActions):
         index = self.currentIndex()
         if not index.isValid():
             return
@@ -77,7 +77,7 @@ class MessageTreeWidget(QTreeView):  # noqa
         drag.exec_()
 
     @Slot('QPoint')
-    def handle_customContextMenuRequested(self, pos):  # noqa
+    def handle_customContextMenuRequested(self, pos):
         # show context menu
         menu = QMenu(self)
         self._context_menu_add_actions(menu, pos)
@@ -103,7 +103,7 @@ class MessageTreeWidget(QTreeView):  # noqa
             recursive_set_expanded(index)
 
     @Slot('QPoint')
-    def handle_header_view_customContextMenuRequested(self, pos):  # noqa
+    def handle_header_view_customContextMenuRequested(self, pos):
 
         # create context menu
         menu = QMenu(self)

--- a/rqt_py_common/src/rqt_py_common/message_tree_widget.py
+++ b/rqt_py_common/src/rqt_py_common/message_tree_widget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3  # noqa
 
 # Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.
@@ -30,14 +30,14 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from python_qt_binding.QtCore import Slot, QMimeData, QModelIndex, Qt, qWarning
+from python_qt_binding.QtCore import Slot, QMimeData, QModelIndex, Qt, qWarning   # noqa
 from python_qt_binding.QtGui import QDrag, QIcon
 from python_qt_binding.QtWidgets import QAction, QHeaderView, QMenu, QTreeView
 
 
-class MessageTreeWidget(QTreeView):
+class MessageTreeWidget(QTreeView):  # noqa
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None):  # noqa
         super(MessageTreeWidget, self).__init__(parent)
         self.setDragEnabled(True)
         self.sortByColumn(0, Qt.AscendingOrder)
@@ -53,11 +53,12 @@ class MessageTreeWidget(QTreeView):
 
         self._action_item_expand = QAction(QIcon.fromTheme('zoom-in'), 'Expand Selected', self)
         self._action_item_expand.triggered.connect(self._handle_action_item_expand)
-        self._action_item_collapse = QAction(QIcon.fromTheme('zoom-out'), 'Collapse Selected', self)
+        self._action_item_collapse = QAction(
+            QIcon.fromTheme('zoom-out'), 'Collapse Selected', self)
         self._action_item_collapse.triggered.connect(self._handle_action_item_collapse)
         self.customContextMenuRequested.connect(self.handle_customContextMenuRequested)
 
-    def startDrag(self, supportedActions):
+    def startDrag(self, supportedActions):  # noqa
         index = self.currentIndex()
         if not index.isValid():
             return
@@ -76,7 +77,7 @@ class MessageTreeWidget(QTreeView):
         drag.exec_()
 
     @Slot('QPoint')
-    def handle_customContextMenuRequested(self, pos):
+    def handle_customContextMenuRequested(self, pos):  # noqa
         # show context menu
         menu = QMenu(self)
         self._context_menu_add_actions(menu, pos)
@@ -102,7 +103,7 @@ class MessageTreeWidget(QTreeView):
             recursive_set_expanded(index)
 
     @Slot('QPoint')
-    def handle_header_view_customContextMenuRequested(self, pos):
+    def handle_header_view_customContextMenuRequested(self, pos):  # noqa
 
         # create context menu
         menu = QMenu(self)

--- a/rqt_py_common/src/rqt_py_common/plugin_container_widget.py
+++ b/rqt_py_common/src/rqt_py_common/plugin_container_widget.py
@@ -76,7 +76,7 @@ class PluginContainerWidget(QWidget):
         """
         super(PluginContainerWidget, self).__init__()
 
-        self._logger = rclpy.logging.get_logger("PluginContainerWidget")
+        self._logger = rclpy.logging.get_logger('PluginContainerWidget')
         _, package_path = get_resource('packages', 'rqt_py_common')
         ui_file = os.path.join(
             package_path, 'share', 'rqt_py_common', 'resource', 'plugin_container.ui')

--- a/rqt_py_common/src/rqt_py_common/plugin_container_widget.py
+++ b/rqt_py_common/src/rqt_py_common/plugin_container_widget.py
@@ -46,6 +46,8 @@ import rclpy.logging
 
 class PluginContainerWidget(QWidget):
     """
+    PluginContainerWidget.
+
     This widget accommodates a plugin widget that needs an area to show system
     message. A plugin widget is the pane that provides plugin's main
     functionalities. PluginContainerWidget visually encapsulates a plugin
@@ -66,6 +68,8 @@ class PluginContainerWidget(QWidget):
     def __init__(self, plugin_widget,
                  on_sys_msg=True, on_sysprogress_bar=True):
         """
+        PluginContainerWidget().
+
         @param plugin_widget: The main widget of an rqt plugin.
         @type plugin_widget: QWidget
         @type on_sys_msg: bool
@@ -100,12 +104,14 @@ class PluginContainerWidget(QWidget):
             self._sysprogress_bar.hide()
 
     def set_sysprogress(self, sysprogress):
+        """PluginContainerWidget.set_sysprogress."""
         # TODO: Pass progress value
         pass
 
     def set_sysmsg(self, sysmsg):
         """
         Set system msg that's supposed to be shown in sys msg pane.
+
         @type sysmsg: str
         """
         self._logger.info('{}'.format(sysmsg))
@@ -113,13 +119,13 @@ class PluginContainerWidget(QWidget):
         self._sysmsg_widget.append(sysmsg)
 
     def shutdown(self):
-
+        """PluginContainerWidget.shutdown."""
         # TODO: Is shutdown step necessary for PluginContainerWidget?
 
         self._plugin_widget.shutdown()
 
     def save_settings(self, plugin_settings, instance_settings):
-
+        """PluginContainerWidget.save_settings."""
         # Save setting of PluginContainerWidget.
         instance_settings.set_value('_splitter', self._splitter.saveState())
 
@@ -127,7 +133,7 @@ class PluginContainerWidget(QWidget):
         self._plugin_widget.save_settings(plugin_settings, instance_settings)
 
     def restore_settings(self, plugin_settings, instance_settings):
-
+        """PluginContainerWidget.restore_settings."""
         # Restore the setting of PluginContainerWidget, separate from
         # ContainED widget.
         if instance_settings.contains('_splitter'):

--- a/rqt_py_common/src/rqt_py_common/rqt_ros_graph.py
+++ b/rqt_py_common/src/rqt_py_common/rqt_ros_graph.py
@@ -1,4 +1,4 @@
-# Software License Agreement (BSD License)  # noqa
+# Software License Agreement (BSD License)
 #
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
@@ -39,7 +39,7 @@ from python_qt_binding.QtCore import Qt
 from rclpy import logging
 
 
-class RqtRosGraph(object):  # noqa
+class RqtRosGraph(object):
     _logger = logging.get_logger('RqtRosGraph')
     DELIM_GRN = '/'
 
@@ -66,7 +66,7 @@ class RqtRosGraph(object):  # noqa
         children_grn_list = RqtRosGraph.get_lower_grn_dfs(model_index)
         parent_data = model_index.data()
         RqtRosGraph._logger.debug('parent_data={}'.format(parent_data))
-        if parent_data == None:  # model_index is 1st-order node of a tree.  # noqa
+        if parent_data == None:  # model_index is 1st-order node of a tree.
             upper_grn = RqtRosGraph.get_upper_grn(model_index, '')
             grn_list = []
             for child_grn in children_grn_list:
@@ -87,7 +87,7 @@ class RqtRosGraph(object):  # noqa
 
     @staticmethod
     def get_lower_grn_dfs(model_index, grn_prev=''):
-        """  # noqa
+        """
         Traverse all children treenodes and returns a list of "partial"
         GRNs. Partial means that this method returns names under current level.
 
@@ -144,8 +144,8 @@ class RqtRosGraph(object):  # noqa
             list_grn_children = RqtRosGraph.get_lower_grn_dfs(child_qmindex,
                                                               grn_curr)
             for child_grn in list_grn_children:
-                child_grn = (grn_prev +  # noqa
-                             (RqtRosGraph.DELIM_GRN + grn_curr) +  # noqa
+                child_grn = (grn_prev +
+                             (RqtRosGraph.DELIM_GRN + grn_curr) +
                              (RqtRosGraph.DELIM_GRN + child_grn))
 
             list_grn_children_all = list_grn_children_all + list_grn_children
@@ -159,11 +159,11 @@ class RqtRosGraph(object):  # noqa
         return list_grn_children_all
 
     @staticmethod
-    def get_upper_grn(model_index, str_grn):  # noqa
-        if model_index.data(Qt.DisplayRole) == None:  # noqa
+    def get_upper_grn(model_index, str_grn):
+        if model_index.data(Qt.DisplayRole) == None:
             return str_grn
-        str_grn = (RqtRosGraph.DELIM_GRN +  # noqa
-                   str(model_index.data(Qt.DisplayRole)) +  # noqa
+        str_grn = (RqtRosGraph.DELIM_GRN +
+                   str(model_index.data(Qt.DisplayRole)) +
                    str_grn)
         RqtRosGraph._logger.debug(
             'get_full_grn_recur out str={}'.format(

--- a/rqt_py_common/src/rqt_py_common/rqt_ros_graph.py
+++ b/rqt_py_common/src/rqt_py_common/rqt_ros_graph.py
@@ -1,4 +1,4 @@
-# Software License Agreement (BSD License)
+# Software License Agreement (BSD License)  # noqa
 #
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
@@ -39,8 +39,8 @@ from python_qt_binding.QtCore import Qt
 from rclpy import logging
 
 
-class RqtRosGraph(object):
-    _logger = logging.get_logger("RqtRosGraph")
+class RqtRosGraph(object):  # noqa
+    _logger = logging.get_logger('RqtRosGraph')
     DELIM_GRN = '/'
 
     @staticmethod
@@ -66,7 +66,7 @@ class RqtRosGraph(object):
         children_grn_list = RqtRosGraph.get_lower_grn_dfs(model_index)
         parent_data = model_index.data()
         RqtRosGraph._logger.debug('parent_data={}'.format(parent_data))
-        if parent_data == None:  # model_index is 1st-order node of a tree.
+        if parent_data == None:  # model_index is 1st-order node of a tree.  # noqa
             upper_grn = RqtRosGraph.get_upper_grn(model_index, '')
             grn_list = []
             for child_grn in children_grn_list:
@@ -87,7 +87,7 @@ class RqtRosGraph(object):
 
     @staticmethod
     def get_lower_grn_dfs(model_index, grn_prev=''):
-        """
+        """  # noqa
         Traverse all children treenodes and returns a list of "partial"
         GRNs. Partial means that this method returns names under current level.
 
@@ -144,8 +144,8 @@ class RqtRosGraph(object):
             list_grn_children = RqtRosGraph.get_lower_grn_dfs(child_qmindex,
                                                               grn_curr)
             for child_grn in list_grn_children:
-                child_grn = (grn_prev +
-                             (RqtRosGraph.DELIM_GRN + grn_curr) +
+                child_grn = (grn_prev +  # noqa
+                             (RqtRosGraph.DELIM_GRN + grn_curr) +  # noqa
                              (RqtRosGraph.DELIM_GRN + child_grn))
 
             list_grn_children_all = list_grn_children_all + list_grn_children
@@ -159,11 +159,11 @@ class RqtRosGraph(object):
         return list_grn_children_all
 
     @staticmethod
-    def get_upper_grn(model_index, str_grn):
-        if model_index.data(Qt.DisplayRole) == None:
+    def get_upper_grn(model_index, str_grn):  # noqa
+        if model_index.data(Qt.DisplayRole) == None:  # noqa
             return str_grn
-        str_grn = (RqtRosGraph.DELIM_GRN +
-                   str(model_index.data(Qt.DisplayRole)) +
+        str_grn = (RqtRosGraph.DELIM_GRN +  # noqa
+                   str(model_index.data(Qt.DisplayRole)) +  # noqa
                    str_grn)
         RqtRosGraph._logger.debug(
             'get_full_grn_recur out str={}'.format(

--- a/rqt_py_common/src/rqt_py_common/rqt_roscomm_util.py
+++ b/rqt_py_common/src/rqt_py_common/rqt_roscomm_util.py
@@ -39,12 +39,12 @@ from ament_index_python import get_resources
 from rclpy import logging
 
 
-class RqtRoscommUtil(object):
-    _logger = logging.get_logger("RqtRoscommUtil")
+class RqtRoscommUtil(object):  # noqa
+    _logger = logging.get_logger('RqtRoscommUtil')
 
     @staticmethod
     def load_parameters(config, caller_id):
-        """
+        """  # noqa
         NOTE: Mlautman 11/2/18
               This function has been deprecated as ROS2 does not yet support setting
               and getting of parameters in Python
@@ -102,12 +102,12 @@ class RqtRoscommUtil(object):
         #         "load_parameters: unable to set params (last param was [%s]): %s" % (param, e))
         #     raise  # re-raise as this is fatal
         # RqtRoscommUtil._logger.debug("... load_parameters complete")
-        RqtRoscommUtil._logger.error("load_parameters: not yet implemented in ROS2))")
+        RqtRoscommUtil._logger.error('load_parameters: not yet implemented in ROS2))')
         pass
 
     @staticmethod
     def iterate_packages(subdir):
-        """
+        """  # noqa
         Iterator for packages that contain the given subdir.
 
         This method is generalizing rosmsg.iterate_packages.
@@ -129,7 +129,7 @@ class RqtRoscommUtil(object):
 
     @staticmethod
     def list_files(package, subdir, file_extension='.launch'):
-        """
+        """  # noqa
         Note: Mlautman 11/2/2018
               This method is deprecated in ROS2
               This functionality does not fit the ROS2 design paradigm
@@ -144,12 +144,12 @@ class RqtRoscommUtil(object):
         @param file_extension: Defaults to '.launch', ``str``
         :returns: list of msgs/srv in package, ``[str]``
         """
-        RqtRoscommUtil._logger.error("list_files: not implemented in ROS2))")
+        RqtRoscommUtil._logger.error('list_files: not implemented in ROS2))')
         pass
 
     @staticmethod
     def _list_types(path, ext):
-        """
+        """  # noqa
         Taken from rosmsg
 
         List all messages in the specified package
@@ -169,7 +169,7 @@ class RqtRoscommUtil(object):
 
     @staticmethod
     def _list_resources(path, rfilter=os.path.isfile):
-        """
+        """  # noqa
         Taken from rosmsg._list_resources
 
         List resources in a package directory within a particular
@@ -187,9 +187,9 @@ class RqtRoscommUtil(object):
 
     @staticmethod
     def _msg_filter(ext):
-        """Taken from rosmsg._msg_filter"""
+        """Taken from rosmsg._msg_filter"""  # noqa
         def mfilter(f):
-            """
+            """  # noqa
             Predicate for filtering directory list. matches message files
             :param f: filename, ``str``
             """

--- a/rqt_py_common/src/rqt_py_common/rqt_roscomm_util.py
+++ b/rqt_py_common/src/rqt_py_common/rqt_roscomm_util.py
@@ -39,12 +39,12 @@ from ament_index_python import get_resources
 from rclpy import logging
 
 
-class RqtRoscommUtil(object):  # noqa
+class RqtRoscommUtil(object):
     _logger = logging.get_logger('RqtRoscommUtil')
 
     @staticmethod
     def load_parameters(config, caller_id):
-        """  # noqa
+        """
         NOTE: Mlautman 11/2/18
               This function has been deprecated as ROS2 does not yet support setting
               and getting of parameters in Python
@@ -107,7 +107,7 @@ class RqtRoscommUtil(object):  # noqa
 
     @staticmethod
     def iterate_packages(subdir):
-        """  # noqa
+        """
         Iterator for packages that contain the given subdir.
 
         This method is generalizing rosmsg.iterate_packages.
@@ -129,7 +129,7 @@ class RqtRoscommUtil(object):  # noqa
 
     @staticmethod
     def list_files(package, subdir, file_extension='.launch'):
-        """  # noqa
+        """
         Note: Mlautman 11/2/2018
               This method is deprecated in ROS2
               This functionality does not fit the ROS2 design paradigm
@@ -149,7 +149,7 @@ class RqtRoscommUtil(object):  # noqa
 
     @staticmethod
     def _list_types(path, ext):
-        """  # noqa
+        """
         Taken from rosmsg
 
         List all messages in the specified package
@@ -169,7 +169,7 @@ class RqtRoscommUtil(object):  # noqa
 
     @staticmethod
     def _list_resources(path, rfilter=os.path.isfile):
-        """  # noqa
+        """
         Taken from rosmsg._list_resources
 
         List resources in a package directory within a particular
@@ -187,9 +187,9 @@ class RqtRoscommUtil(object):  # noqa
 
     @staticmethod
     def _msg_filter(ext):
-        """Taken from rosmsg._msg_filter"""  # noqa
+        """Taken from rosmsg._msg_filter"""
         def mfilter(f):
-            """  # noqa
+            """
             Predicate for filtering directory list. matches message files
             :param f: filename, ``str``
             """

--- a/rqt_py_common/src/rqt_py_common/topic_dict.py
+++ b/rqt_py_common/src/rqt_py_common/topic_dict.py
@@ -32,15 +32,32 @@ import rclpy
 
 from rqt_py_common.topic_helpers import get_message_class, get_topic_names_and_types
 
+
 class TopicDict(object):
+    """TopicDict class."""
 
     def __init__(self, node=None):
+        """
+        TopicDict(node).
+
+        Create a Topic Dict with an option node passed in
+        """
         self.update_topics(node=node)
 
     def get_topics(self):
+        """
+        get_topics.
+
+        Get the topic dictionary
+        """
         return self.topic_dict
 
     def update_topics(self, node=None):
+        """
+        update_topics.
+
+        Update the topics contained in the dictionary with new information from a node
+        """
         # NOTE: This has changed from ROS1 to ROS2 since ROS2 seems to support
         #       multiple msg types on a single topic
         self.topic_dict = {}
@@ -75,7 +92,7 @@ class TopicDict(object):
 if __name__ == '__main__':
     import pprint
     rclpy.init()
-    topic_dict_node = rclpy.create_node("topic_dict")
+    topic_dict_node = rclpy.create_node('topic_dict')
     pprint.pprint(TopicDict(node=topic_dict_node).get_topics())
     topic_dict_node.destroy_node()
     rclpy.shutdown()

--- a/rqt_py_common/src/rqt_py_common/topic_helpers.py
+++ b/rqt_py_common/src/rqt_py_common/topic_helpers.py
@@ -46,8 +46,15 @@ def get_topic_names_and_types(node=None):
     If node is None, then this method will create a node, use it to get topic
     information and then destroy the node.
     """
+    # TODO(mlautman): Replace this approach with the daemon approach used by ros2cli
+    logger = logging.get_logger('get_topic_names_and_types')
     if node is not None:
-        return node.get_topic_names_and_types()
+        try:
+            return node.get_topic_names_and_types()
+        except ValueError:
+            logger.warn('method called with an invalid node!')
+    else:
+        logger.warn('calling get_topic_names_and_types without passing in a node is really slow!')
 
     import rclpy
     shutdown_rclpy = False

--- a/rqt_py_common/src/rqt_py_common/topic_helpers.py
+++ b/rqt_py_common/src/rqt_py_common/topic_helpers.py
@@ -55,7 +55,7 @@ def get_topic_names_and_types(node=None):
         shutdown_rclpy = True
         rclpy.init()
 
-    node = rclpy.create_node("TopicHelpers__get_topic_names_and_types")
+    node = rclpy.create_node('TopicHelpers__get_topic_names_and_types')
 
     # Give the node time to learn about the graph
     rclpy.spin_once(node, timeout_sec=0.5)
@@ -69,22 +69,28 @@ def get_topic_names_and_types(node=None):
     return topic_list
 
 
-_message_class_cache = {}
+_message_class_cache = {}  # noqa
 def get_message_class(message_type):
-    logger = logging.get_logger("get_message_class")
+    """
+    get_message_class: gets the message class from a string representation.
+
+    @param message_type: the type of message in the form `msg_pkg/Message`
+    @type message_type: str
+    """
+    logger = logging.get_logger('get_message_class')
     if message_type in _message_class_cache:
         return _message_class_cache[message_type]
 
-    message_info = message_type.split("/")
+    message_info = message_type.split('/')
     if len(message_info) == 2:
         package = message_info[0]
         base_type = message_info[1]
     elif len(message_info) == 1:
-        package = "std_msgs"
+        package = 'std_msgs'
         base_type = message_info[0]
     else:
         logger.error(
-            "Malformed message_type passed into get_message_class: {}".format(
+            'Malformed message_type passed into get_message_class: {}'.format(
                 message_type))
         return None
 
@@ -94,20 +100,20 @@ def get_message_class(message_type):
         # import the package
         python_pkg = __import__('%s.%s' % (package, "msg"))
     except ImportError:
-        logger.error("Failed to get message class: {}".format(message_type))
+        logger.error('Failed to get message class: {}'.format(message_type))
 
     if python_pkg:
         try:
-            class_val = getattr(getattr(python_pkg, "msg"), base_type)
+            class_val = getattr(getattr(python_pkg, 'msg'), base_type)
         except AttributeError:
             if len(base_type):
-                base_type = "".join([base_type[0].upper(), base_type[1:]])
+                base_type = ''.join([base_type[0].upper(), base_type[1:]])
 
         if not class_val:
             try:
-                class_val = getattr(getattr(python_pkg, "msg"), base_type)
+                class_val = getattr(getattr(python_pkg, 'msg'), base_type)
             except AttributeError:
-                logger.error("Failed to get message class: {}".format(message_type))
+                logger.error('Failed to get message class: {}'.format(message_type))
 
     if class_val:
         _message_class_cache[message_type] = class_val
@@ -116,7 +122,14 @@ def get_message_class(message_type):
 
 
 def get_type_class(type_name):
+    """
+    get_type_class: gets the python type from an idl string.
 
+    See: https://github.com/ros2/design/blob/gh-pages/articles/142_idl.md
+
+    @param type_name: the IDL type of field
+    @type message_type: str
+    """
     if type_name in ['float32', 'float64']:
         return float
 
@@ -132,7 +145,7 @@ def get_type_class(type_name):
             'char', 'byte']:
         return int
 
-    elif type_name in ["bool"]:
+    elif type_name in ['bool']:
         return bool
 
     else:

--- a/rqt_py_common/src/rqt_py_common/topic_helpers.py
+++ b/rqt_py_common/src/rqt_py_common/topic_helpers.py
@@ -70,7 +70,7 @@ def get_topic_names_and_types(node=None):
 
 
 _message_class_cache = {}  # noqa
-def get_message_class(message_type):
+def get_message_class(message_type):  # noqa
     """
     get_message_class: gets the message class from a string representation.
 
@@ -98,7 +98,7 @@ def get_message_class(message_type):
     python_pkg = class_val = None
     try:
         # import the package
-        python_pkg = __import__('%s.%s' % (package, "msg"))
+        python_pkg = __import__('%s.%s' % (package, 'msg'))
     except ImportError:
         logger.error('Failed to get message class: {}'.format(message_type))
 
@@ -168,8 +168,8 @@ def get_field_types(topic_name):
     # Note: Mlautman 11/2/18
     #       In ROS2 multiple msg types can be used with a single topic making this
     #       funciton a bad candidate to port to ROS2
-    logger = logging.get_logger("topic_helpers")
-    logger.error("get_field_type is not implemented in ROS2")
+    logger = logging.get_logger('topic_helpers')
+    logger.error('get_field_type is not implemented in ROS2')
     # get topic_type and message_evaluator
     # topic_type, real_topic_name, _ = get_topic_type(topic_name)
     # if topic_type is None:

--- a/rqt_py_common/src/rqt_py_common/topic_helpers.py
+++ b/rqt_py_common/src/rqt_py_common/topic_helpers.py
@@ -130,22 +130,24 @@ def get_type_class(type_name):
     @param type_name: the IDL type of field
     @type message_type: str
     """
-    if type_name in ['float32', 'float64']:
+    if type_name in ['float', 'float32', 'float64',
+                     'double', 'long double']:
         return float
 
-    elif type_name in ['string']:
-        # string constants are always stripped
+    elif type_name in ['char', 'wchar', 'string', 'wstring']:
         return str
+
+    elif type_name in ['octet']:
+        return bytes
 
     elif type_name in [
             'int8', 'uint8',
             'int16', 'uint16',
             'int32', 'uint32',
-            'int64', 'uint64',
-            'char', 'byte']:
+            'int64', 'uint64']:
         return int
 
-    elif type_name in ['bool']:
+    elif type_name in ['bool', 'boolean']:
         return bool
 
     else:

--- a/rqt_py_common/src/rqt_py_common/topic_helpers.py
+++ b/rqt_py_common/src/rqt_py_common/topic_helpers.py
@@ -76,8 +76,8 @@ def get_topic_names_and_types(node=None):
     return topic_list
 
 
-_message_class_cache = {}  # noqa
-def get_message_class(message_type):  # noqa
+_message_class_cache = {}
+def get_message_class(message_type):  # noqa: C901 E302
     """
     get_message_class: gets the message class from a string representation.
 
@@ -128,6 +128,24 @@ def get_message_class(message_type):  # noqa
     return class_val
 
 
+def _is_primative_type(type_str):
+    # Note: this list a combination of primitive types from ROS1 and the new IDL definitions
+    primitive_types = [
+        'int8', 'uint8',
+        'int16', 'uint16',
+        'int32', 'uint32',
+        'int64', 'uint64',
+        'float', 'float32', 'float64',
+        'double', 'long double',
+        'char', 'wchar',
+        'octet',
+        'string',
+        'bool', 'boolean',
+        # deprecated in ros1:
+        'char', 'byte']
+    return type_str in primitive_types
+
+
 def get_type_class(type_name):
     """
     get_type_class: gets the python type from an idl string.
@@ -137,61 +155,96 @@ def get_type_class(type_name):
     @param type_name: the IDL type of field
     @type message_type: str
     """
+    # Note: this list a combination of primitive types from ROS1 and the new IDL definitions
+
+    if not _is_primative_type(type_name):
+        return get_message_class(type_name)
+
     if type_name in ['float', 'float32', 'float64',
                      'double', 'long double']:
         return float
 
-    elif type_name in ['char', 'wchar', 'string', 'wstring']:
+    # TODO(mlautman): char should be a string of lenght one. We do not currently suppor this
+    if type_name in ['char', 'wchar', 'string', 'wstring']:
         return str
 
-    elif type_name in ['octet']:
+    if type_name in ['octet']:
         return bytes
 
-    elif type_name in [
+    if type_name in [
             'int8', 'uint8',
             'int16', 'uint16',
             'int32', 'uint32',
             'int64', 'uint64']:
         return int
 
-    elif type_name in ['bool', 'boolean']:
+    if type_name in ['bool', 'boolean']:
         return bool
 
-    else:
-        return None
+    return None
 
 
-def get_field_types(topic_name):
+def get_field_type(target, node=None):
     """
     Get the Python type of a specific field in the given registered topic.
 
-    If the field is an array, the type of the array's values are returned and the is_array flag is
-    set to True. This is a static type check, so it works for unpublished topics and with empty
-    arrays.
+    If the field is an array, the type of the array's values are returned and the is_array flag
+    is set to True
 
-    :param topic_name: name of field of a registered topic, ``str``, i.e. '/rosout/file'
+    :param target: name of field of a registered topic, ``str``, i.e. '/rosout/file'
     :returns: field_type, is_array
     """
-    # Note: Mlautman 11/2/18
-    #       In ROS2 multiple msg types can be used with a single topic making this
-    #       funciton a bad candidate to port to ROS2
-    logger = logging.get_logger('topic_helpers')
-    logger.error('get_field_type is not implemented in ROS2')
-    # get topic_type and message_evaluator
-    # topic_type, real_topic_name, _ = get_topic_type(topic_name)
-    # if topic_type is None:
-    #     # qDebug('topic_helpers.get_field_type(%s): get_topic_type failed' % (topic_name))
-    #     return None, False
+    topic_names_and_types = get_topic_names_and_types(node=node)
+    return _get_field_type(topic_names_and_types, target)
 
-    # message_class = roslib.message.get_message_class(topic_type)
-    # if message_class is None:
-    #     qDebug('topic_helpers.get_field_type(%s): get_message_class(%s) failed' %
-    #            (topic_name, topic_type))
-    #     return None, False
 
-    # slot_path = topic_name[len(real_topic_name):]
-    # return get_slot_type(message_class, slot_path)
-    pass
+def _get_field_type(topic_names_and_types, target):
+    """Testable helper function for get_field_type."""
+    logger = logging.get_logger('topic_helpers._get_field_type')
+    for name, types in topic_names_and_types:
+        # If the topic is a substring of the target param, then we have found a match
+        if target.find(name) >= 0:
+            # If the target passed in was the topic address not the address of a field
+            if target == name:
+                # If there is more than one type of topic on target
+                if len(types) > 1:
+                    logger.warn(
+                        'Ambiguous request. Multiple topic types found on: {}'.format(target))
+                    return None, False
+                # If the types array is empty then something weird has happend
+                if len(types) == 0:
+                    logger.warn(
+                        'Ambiguous request. No topic types found on: {}'.format(target))
+                    return None, False
+
+                # If there is only one msg class on
+                msg_type_str = types[0]
+                msg_class = get_type_class(msg_type_str)
+                return msg_class, False
+
+            else:
+                # The topic must be a substring of the target
+
+                # Get the address of the field in the messgage class
+                field_address_str = target[len(name):]
+
+                # Iterate through the message types on the given topic and see if any match the
+                # path that was provided
+                for msg_type_str in types:
+                    try:
+                        msg_class = get_message_class(msg_type_str)
+
+                        # If the message type is a simple type eg: float, then it can't be an array
+                        if _is_primative_type(msg_type_str):
+                            return msg_class, False
+
+                        field_type, is_array = get_slot_type(msg_class, field_address_str)
+                        return field_type, is_array
+                    except ValueError:
+                        pass
+
+    logger.debug('faild to find field type: {}'.format(target))
+    return None, False
 
 
 def get_slot_type(message_class, slot_path):
@@ -211,6 +264,6 @@ def get_slot_type(message_class, slot_path):
     for field_name in fields:
         slot_class_name = message_class._slot_types[message_class.__slots__.index(field_name)]
         is_array = slot_class_name.find('[') >= 0
-        message_class = get_message_class(slot_class_name[:slot_class_name.find('[')])
+        message_class = get_type_class(slot_class_name[:slot_class_name.find('[')])
 
     return message_class, is_array

--- a/rqt_py_common/src/rqt_py_common/topic_helpers.py
+++ b/rqt_py_common/src/rqt_py_common/topic_helpers.py
@@ -58,7 +58,7 @@ def get_topic_names_and_types(node=None):
     node = rclpy.create_node("TopicHelpers__get_topic_names_and_types")
 
     # Give the node time to learn about the graph
-    rclpy.spin_once(node, timeout_sec=0.05)
+    rclpy.spin_once(node, timeout_sec=0.5)
 
     topic_list = node.get_topic_names_and_types()
 

--- a/rqt_py_common/test/test_rqt_common_unit.py
+++ b/rqt_py_common/test/test_rqt_common_unit.py
@@ -35,11 +35,11 @@
 import unittest
 
 
-class TestMessageTreeModel(unittest.TestCase):
+class TestMessageTreeModel(unittest.TestCase):  # noqa
 
-    def test_path_names(self):
+    def test_path_names(self):  # noqa
         from rqt_py_common.message_tree_model import MessageTreeModel
-        from rqt_py_common.msg import Val, ArrayVal
+        from rqt_py_common.msg import Val, ArrayVal  # noqa
         m = MessageTreeModel()
         m.add_message(ArrayVal())
         root = m.item(0).child(0)

--- a/rqt_py_common/test/test_rqt_ros_graph.py
+++ b/rqt_py_common/test/test_rqt_ros_graph.py
@@ -37,15 +37,16 @@
 import unittest
 
 from python_qt_binding.QtGui import QStandardItem, QStandardItemModel
+
 from rqt_py_common.rqt_ros_graph import RqtRosGraph
 
 
 class TestRqtRosGraph(unittest.TestCase):
-    """
+    """  # noqa
     :author: Isaac Saito
     """
 
-    def setUp(self):
+    def setUp(self):  # noqa
         unittest.TestCase.setUp(self)
 
         self._model = QStandardItemModel()
@@ -68,15 +69,15 @@ class TestRqtRosGraph(unittest.TestCase):
         self._grn_node1_1_1 = '/node1/node1_1/node1_1_1'
         self._len_lower_grn_node1_1 = 2
 
-    def tearDown(self):
+    def tearDown(self):  # noqa
         unittest.TestCase.tearDown(self)
         del self._model
 
-    def test_get_upper_grn(self):
+    def test_get_upper_grn(self):  # noqa
         self.assertEqual(RqtRosGraph.get_upper_grn(self._node1_1_1.index(), ''),
                          self._grn_node1_1_1)
 
-    def test_get_lower_grn_dfs(self):
+    def test_get_lower_grn_dfs(self):  # noqa
         self.assertEqual(
             len(RqtRosGraph.get_lower_grn_dfs(
                 self._node1_1.index(), '')),

--- a/rqt_py_common/test/test_rqt_roscomm_util.py
+++ b/rqt_py_common/test/test_rqt_roscomm_util.py
@@ -39,18 +39,18 @@ import unittest
 
 
 class TestRqtRoscommUtil(unittest.TestCase):
-    """@author: Isaac Saito"""
+    """@author: Isaac Saito"""  # noqa
 
-    def setUp(self):
+    def setUp(self):  # noqa
         unittest.TestCase.setUp(self)
 
-    def tearDown(self):
+    def tearDown(self):  # noqa
         unittest.TestCase.tearDown(self)
         # del self._model
 
     # TODO(mlautman): Replace this test with an apropriate ROS2 test.
     def test_iterate_packages(self):
-        """
+        """  # noqa
         Not a very good test
         """
         # Note: mlautman 11/2/18
@@ -65,5 +65,5 @@ class TestRqtRoscommUtil(unittest.TestCase):
             path_to_msg_dir, msg_dir = os.path.split(msg_dir_path)
             self.assertEqual(msg_dir, 'msg')
 
-        print("number of packages:\t{}".format(pkg_num_sum))
+        print('number of packages:\t{}'.format(pkg_num_sum))
         self.assertNotEqual(pkg_num_sum, 0)

--- a/rqt_py_common/test/test_rqt_topic_helpers.py
+++ b/rqt_py_common/test/test_rqt_topic_helpers.py
@@ -37,21 +37,21 @@
 import unittest
 
 
-class TestTopicHelpers(unittest.TestCase):
+class TestTopicHelpers(unittest.TestCase): # noqa
 
-    def test_get_message_class(self):
+    def test_get_message_class(self):  # noqa
         from rqt_py_common.topic_helpers import get_message_class
         # Check that we are able to import std_msgs/String
         from std_msgs.msg import String
-        self.assertEqual(get_message_class("std_msgs/String"), String)
+        self.assertEqual(get_message_class('std_msgs/String'), String)
         # If no package is provided then we assume std_msgs
-        self.assertEqual(get_message_class("String"), get_message_class("std_msgs/String"))
-        self.assertEqual(get_message_class("string"), get_message_class("String"))
+        self.assertEqual(get_message_class('String'), get_message_class('std_msgs/String'))
+        self.assertEqual(get_message_class('string'), get_message_class('String'))
         # We test that we are able to import msgs from outside of std_msgs
         from rqt_py_common.msg import Val
-        self.assertEqual(get_message_class("rqt_py_common/Val"), Val)
+        self.assertEqual(get_message_class('rqt_py_common/Val'), Val)
 
-    def test_get_slot_type(self):
+    def test_get_slot_type(self): # noqa
         from rqt_py_common.topic_helpers import get_slot_type
         from rqt_py_common.topic_helpers import get_message_class
         from rqt_py_common.msg import ArrayVal
@@ -60,4 +60,4 @@ class TestTopicHelpers(unittest.TestCase):
         message_class = ArrayVal
         message_type, is_array = get_slot_type(message_class, path)
         self.assertTrue(is_array)
-        self.assertEqual(message_type, get_message_class("float64"))
+        self.assertEqual(message_type, get_message_class('float64'))

--- a/rqt_py_common/test/test_rqt_topic_helpers.py
+++ b/rqt_py_common/test/test_rqt_topic_helpers.py
@@ -51,7 +51,7 @@ class TestTopicHelpers(unittest.TestCase): # noqa
         from rqt_py_common.msg import Val
         self.assertEqual(get_message_class('rqt_py_common/Val'), Val)
 
-    def test_get_slot_type(self): # noqa
+    def test_get_slot_type(self):  # noqa
         from rqt_py_common.topic_helpers import get_slot_type
         from rqt_py_common.topic_helpers import get_message_class
         from rqt_py_common.msg import ArrayVal
@@ -60,4 +60,30 @@ class TestTopicHelpers(unittest.TestCase): # noqa
         message_class = ArrayVal
         message_type, is_array = get_slot_type(message_class, path)
         self.assertTrue(is_array)
-        self.assertEqual(message_type, get_message_class('float64'))
+        self.assertEqual(message_type, float)
+
+        path = '/_vals'
+        message_class = ArrayVal
+        message_type, is_array = get_slot_type(message_class, path)
+        self.assertTrue(is_array)
+        self.assertEqual(message_type, get_message_class('rqt_py_common/Val'))
+
+
+    def test_get_field_type(self):  # noqa
+        from rqt_py_common.topic_helpers import _get_field_type
+        from rqt_py_common.msg import ArrayVal, Val
+        target = '/example_topic/_vals/_floats'
+        topic_names_and_types = [('/example_topic', ['rqt_py_common/ArrayVal'])]
+        target_class, is_array = _get_field_type(topic_names_and_types, target)
+        self.assertTrue(is_array)
+        self.assertEqual(target_class, float)
+
+        target = '/example_topic'
+        target_class, is_array = _get_field_type(topic_names_and_types, target)
+        self.assertFalse(is_array)
+        self.assertEqual(target_class, ArrayVal)
+
+        target = '/example_topic/_vals'
+        target_class, is_array = _get_field_type(topic_names_and_types, target)
+        self.assertTrue(is_array)
+        self.assertEqual(target_class, Val)


### PR DESCRIPTION
This pr includes #155 

New commit: 3b61b6e

This implements the get_field_type method.
This also causes the rqt_py_common package to depend on ros2cli packages to make use of the daemon node for getting topics and message types. Ideally this functionality will get split out of ros2cli in the future so that the RQT package no longer depends on a cli package. 

https://ci.ros2.org/job/ci_linux/5512/