### PR TITLE
Subclassing plugin_context to pass around the rqt node

### DIFF
--- a/rqt_gui/src/rqt_gui/ros2_plugin_context.py
+++ b/rqt_gui/src/rqt_gui/ros2_plugin_context.py
@@ -35,9 +35,10 @@ class Ros2PluginContext(PluginContext):
     """
     Provides information to the plugin and exposes methods to interact with the framework.
 
-    PluginContext relays all methods to the corresponding `PluginHandler`.
+    Ros2PluginContext exposes the shared rclpy Node to rqt_gui plugins and relays all methods to the
+    correspending `PluginHandler`
     """
 
     def __init__(self, handler, node):
         super(Ros2PluginContext, self).__init__(handler)
-        self._node = node
+        self.node = node

--- a/rqt_gui/src/rqt_gui/ros2_plugin_context.py
+++ b/rqt_gui/src/rqt_gui/ros2_plugin_context.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2018 PickNik Consulting
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#   * Neither the name of the TU Darmstadt nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from qt_gui.plugin_context import PluginContext
+
+
+class Ros2PluginContext(PluginContext):
+    """
+    Provides information to the plugin and exposes methods to interact with the framework.
+
+    PluginContext relays all methods to the corresponding `PluginHandler`.
+    """
+
+    def __init__(self, handler, node):
+        super(Ros2PluginContext, self).__init__(handler)
+        self._node = node

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -47,9 +47,9 @@ class RosPyPluginProvider(CompositePluginProvider):
         self._node_initialized = False
         self._node = None
 
-    def __del__(self):
+    def shutdown(self):
         self._destroy_node()
-        super().__del__()
+        super().shutdown()
 
     def load(self, plugin_id, plugin_context):
         self._init_node()

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -32,6 +32,7 @@ import os
 
 from python_qt_binding.QtCore import qDebug
 from qt_gui.composite_plugin_provider import CompositePluginProvider
+from rqt_gui.ros2_plugin_context import Ros2PluginContext
 
 import rclpy
 from rqt_gui.rospkg_plugin_provider import RospkgPluginProvider
@@ -46,12 +47,17 @@ class RosPyPluginProvider(CompositePluginProvider):
         self._node_initialized = False
         self._node = None
 
+    def __del__(self):
+        self._destroy_node()
+        super().__del__()
+
     def load(self, plugin_id, plugin_context):
         self._init_node()
-        return super(RosPyPluginProvider, self).load(plugin_id, plugin_context)
+        ros_plugin_context = Ros2PluginContext(handler=plugin_context._handler, node=self._node)
+
+        return super(RosPyPluginProvider, self).load(plugin_id, ros_plugin_context)
 
     def unload(self, plugin_instance):
-        self._destroy_node()
         return super(RosPyPluginProvider, self).unload(plugin_instance)
 
     def _init_node(self):


### PR DESCRIPTION
This adds a derived class Ros2PluginContext, to pass around a ros2 node so that plugins have the ability to communicate with the node graph.