### PR TITLE
Spinning node in separate QThread

### DIFF
--- a/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py
+++ b/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py
@@ -1,0 +1,38 @@
+# Copyright 2018, PickNik Consulting
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python_qt_binding.QtCore import QThread, qWarning, qDebug
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+
+
+class RclpySpinner(QThread):
+    def __init__(self, node):
+        super().__init__()
+        self._node = node
+        self._abort = False
+
+    def run(self):
+        qDebug('Start called on RclpySpinner, spinning ros2 node')
+        executor = MultiThreadedExecutor()
+        executor.add_node(self._node)
+        while rclpy.ok() and not self._abort:
+            executor.spin_once(timeout_sec=1.0)
+        if not self._abort:
+            qWarning('rclpy.shutdown() was before quit was called on this QThread')
+
+    def quit(self):
+        qDebug('Quit called on RclpySpinner')
+        self._abort = True
+        super().quit()

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -36,6 +36,7 @@ from rqt_gui.ros2_plugin_context import Ros2PluginContext
 
 import rclpy
 from rqt_gui.rospkg_plugin_provider import RospkgPluginProvider
+from rqt_gui_py.rclpy_spinner import RclpySpinner
 
 
 class RosPyPluginProvider(CompositePluginProvider):
@@ -48,6 +49,8 @@ class RosPyPluginProvider(CompositePluginProvider):
         self._node = None
 
     def shutdown(self):
+        qDebug('Shutting down RosPyPluginProvider')
+        self.spinner.quit()
         self._destroy_node()
         super().shutdown()
 
@@ -65,8 +68,11 @@ class RosPyPluginProvider(CompositePluginProvider):
         if not self._node_initialized:
             name = 'rqt_gui_py_node_%d' % os.getpid()
             qDebug('RosPyPluginProvider._init_node() initialize ROS node "%s"' % name)
+
             rclpy.init()
             self._node = rclpy.create_node(name)
+            self.spinner = RclpySpinner(self._node)
+            self.spinner.start()
             self._node_initialized = True
 
     def _destroy_node(self):


### PR DESCRIPTION
The node that was added to the plugin_context was not spinning previously so Python subscribers would not work correctly. This now adds a QThread to process the events during spin.