### PR TITLE
Adding test dependency

### DIFF
--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -30,6 +30,7 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>std_srvs</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 


### PR DESCRIPTION
One of the recently added tests depends on std_srvs. This updates the package.xml to include it.