### PR TITLE
fix install destination of plugin.xml

### DIFF
--- a/rqt_gui_py/setup.py
+++ b/rqt_gui_py/setup.py
@@ -10,7 +10,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        ('share/' + package_name + '/resource/', ['plugin.xml'])
+        ('share/' + package_name, ['plugin.xml'])
     ],
     install_requires=['setuptools'],
     zip_safe=False,


### PR DESCRIPTION
The expected location is [${prefix}/plugin.xml](https://github.com/ros-visualization/rqt/blob/fd794145d06310cb8ab44d247e8b63b2ccca4bb8/rqt_gui_py/package.xml#L25) - not in a `resource` subdirectory.