### PR TITLE
Destroy listeners outside of spin_once()

### DIFF
--- a/rqt_gui/src/rqt_gui/ros2_plugin_context.py
+++ b/rqt_gui/src/rqt_gui/ros2_plugin_context.py
@@ -39,6 +39,7 @@ class Ros2PluginContext(PluginContext):
     the corresponding `PluginHandler`
     """
 
-    def __init__(self, handler, node):
+    def __init__(self, handler, node, node_spinner):
         super(Ros2PluginContext, self).__init__(handler)
         self.node = node
+        self.spinner = node_spinner

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -59,7 +59,8 @@ class RosPyPluginProvider(CompositePluginProvider):
 
     def load(self, plugin_id, plugin_context):
         self._init_node()
-        ros_plugin_context = Ros2PluginContext(handler=plugin_context._handler, node=self._node)
+        ros_plugin_context = Ros2PluginContext(handler=plugin_context._handler, node=self._node,
+                                               node_spinner=self._spinner)
 
         return super(RosPyPluginProvider, self).load(plugin_id, ros_plugin_context)
 


### PR DESCRIPTION
Destroying subscriptions is not thread-safe. Because the executor spins the node in a separate QThread outside of the plugins UI threads, destroying listeners needs to happen after spin_once().

This adds a method for plugins to call that registers subscriptions and clients for destruction. Unfortunately this also means that the spinner object needs to be passed around.

This address issue #181 