### PR TITLE
[Windows][kinetic] build break fixes for roscpp_plugin_provider.cpp (adapted from windows_fixes)

### DIFF
--- a/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.cpp
+++ b/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.cpp
@@ -43,7 +43,11 @@
 
 #include <stdexcept>
 #include <sys/types.h>
+#ifdef WIN32
+#include <process.h> // for getpid()
+#else
 #include <unistd.h>
+#endif
 #include <iostream>
 
 namespace rqt_gui_cpp {


### PR DESCRIPTION
- Cherry-pick changes from https://github.com/ros-visualization/rqt/commit/ea83b6a855e141e38bfefc293c569920bcd48076
- Only pick the build break fixes for roscpp_plugin_provider.cpp. Others seem ROS2 changes, so I skip them.

(This is verified in https://aka.ms/ros project.)