### PR TITLE
update test to accept old as well as new type name

### DIFF
--- a/rqt_py_common/test/test_rqt_message_helpers.py
+++ b/rqt_py_common/test/test_rqt_message_helpers.py
@@ -57,8 +57,9 @@ class TestMessageHelpers(unittest.TestCase):  # noqa: D101
         self.assertEqual(text, expected_text)
 
         text = get_message_text_from_class(Val)
-        expected_text = 'float64[5] floats\n'
-        self.assertEqual(text, expected_text)
+        expected_text1 = 'float64[5] floats\n'  # .msg based type name
+        expected_text2 = 'double[5] floats\n'  # .idl based type name
+        self.assertTrue(text in (expected_text1, expected_text2))
 
     def test_get_service_text_from_class(self):  # noqa: D102
         from rqt_py_common.message_helpers import get_service_text_from_class


### PR DESCRIPTION
Connected to [ros2/rosidl#334](https://github.com/ros2/rosidl/pull/334).

While not necessary for Crystal this change avoids the need to branch for now.