### PR TITLE
suppress traceback when ctrl-c

### DIFF
--- a/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py
+++ b/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py
@@ -29,7 +29,11 @@ class RclpySpinner(QThread):
         executor = MultiThreadedExecutor()
         executor.add_node(self._node)
         while rclpy.ok() and not self._abort:
-            executor.spin_once(timeout_sec=1.0)
+            try:
+                executor.spin_once(timeout_sec=1.0)
+            except RuntimeError:
+                if rclpy.ok():
+                    raise
         if not self._abort:
             qWarning('rclpy.shutdown() was called before QThread.quit()')
 


### PR DESCRIPTION
fixes ros-visualization/rqt#198

unfortunately, rclpy doesn't throw a more specific error message than `RuntimeError`. In order to narrow down the reasons for the error, we parse the error message to hit the specific keywords. 

Signed-off-by: Karsten Knese <karsten@openrobotics.org>