### PR TITLE
Drop unnecessary MOC compilation in rqt_gui_cpp

### DIFF
--- a/rqt_gui_cpp/CMakeLists.txt
+++ b/rqt_gui_cpp/CMakeLists.txt
@@ -33,12 +33,6 @@ SET(rqt_gui_cpp_SRCS
   src/rqt_gui_cpp/roscpp_plugin_provider.cpp
 )
 
-set(rqt_gui_cpp_HDRS
-  src/rqt_gui_cpp/roscpp_plugin_provider.h
-)
-
-qt5_wrap_cpp(rqt_gui_cpp_MOCS ${rqt_gui_cpp_HDRS})
-
 ament_export_dependencies(
   Qt5Widgets
   pluginlib
@@ -57,7 +51,7 @@ include_directories(${PROJECT_NAME}
 
 add_library(${PROJECT_NAME} SHARED
   ${rqt_gui_cpp_SRCS}
-  ${rqt_gui_cpp_MOCS})
+)
 
 if(APPLE)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")


### PR DESCRIPTION
This file does not reference `Q_OBJECT`, so metaobject compilation isn't necessary:
https://github.com/ros-visualization/rqt/blob/2dc68b8abc57ed3ab57b154cba529524a2cb7338/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.h#L45-L65

This resolves some extra stderr output during build:
```
Starting >>> rqt_gui_cpp
--- stderr: rqt_gui_cpp                                
src/ros-visualization/rqt/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.h:0: Note: No relevant classes found. No output generated.
---
Finished <<< rqt_gui_cpp [6.24s]
```