### PR TITLE
Use catkin_install_python for python script.

### DIFF
--- a/rqt_gui/CMakeLists.txt
+++ b/rqt_gui/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED COMPONENTS qt_gui)
 catkin_package()
 catkin_python_setup()
 
-install(PROGRAMS bin/rqt_gui
+catkin_install_python(PROGRAMS bin/rqt_gui
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 install(FILES resource/rqt.png


### PR DESCRIPTION
This aids in our Python 3 migration.