### PR TITLE
Drop architecture_independent from rqt_py_common

### DIFF
--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -36,6 +36,5 @@
 
   <export>
     <build_type>ament_cmake</build_type>
-    <architecture_independent/>
   </export>
 </package>


### PR DESCRIPTION
When this flag was added back in 2014 (ros-visualization/rqt_common_plugins#254), the package was indeed architecture-independent. Now this package includes shared object libraries which were created as part of [message generation](https://github.com/ros-visualization/rqt/blob/f549803a6b3129b58e133e7fd19de7a4c1b9357f/rqt_py_common/CMakeLists.txt#L28-L32), making it architecture-specific.

I'm not sure if these messages need to be distributed with the package, but if they are only used for tests, we should find a way to remove them from installation. That would make this package architecture-independent once again.