### PR TITLE
Replace deprecated usage of rclcpp::is_initialized()

### DIFF
--- a/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.cpp
+++ b/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.cpp
@@ -49,7 +49,7 @@ RosCppPluginProvider::RosCppPluginProvider()
   : qt_gui_cpp::CompositePluginProvider()
   , rclcpp_initialized_(false)
 {
-  if (rclcpp::is_initialized(rclcpp::contexts::default_context::get_global_default_context()))
+  if (rclcpp::ok(rclcpp::contexts::default_context::get_global_default_context()))
   {
     rclcpp_initialized_ = true;
   }
@@ -62,7 +62,7 @@ RosCppPluginProvider::RosCppPluginProvider()
 
 RosCppPluginProvider::~RosCppPluginProvider()
 {
-  if (rclcpp::is_initialized(rclcpp::contexts::default_context::get_global_default_context()))
+  if (rclcpp::ok(rclcpp::contexts::default_context::get_global_default_context()))
   {
     rclcpp::shutdown();
   }


### PR DESCRIPTION
Instead use rclcpp::ok()

Related to https://github.com/ros2/rclcpp/pull/967