### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/rqt/CMakeLists.txt
+++ b/rqt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rqt)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/rqt_gui/CMakeLists.txt
+++ b/rqt_gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rqt_gui)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS qt_gui)

--- a/rqt_gui_cpp/CMakeLists.txt
+++ b/rqt_gui_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rqt_gui_cpp)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS qt_gui qt_gui_cpp roscpp nodelet)

--- a/rqt_gui_py/CMakeLists.txt
+++ b/rqt_gui_py/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rqt_gui_py)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS rqt_gui rospy)

--- a/rqt_py_common/CMakeLists.txt
+++ b/rqt_py_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rqt_py_common)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED)


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

ros/catkin#1052