### PR TITLE
add missing dependencies for rqt_gui: rospkg-modules, python_qt_binding, rospy

### DIFF
--- a/rqt_gui/package.xml
+++ b/rqt_gui/package.xml
@@ -1,4 +1,6 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rqt_gui</name>
   <version>0.5.1</version>
   <description>rqt_gui provides the main to start an instance of the ROS integrated graphical user interface provided by qt_gui.</description>
@@ -15,6 +17,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
-  <run_depend>catkin</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui</run_depend>
+
+  <exec_depend>catkin</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg-modules</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg-modules</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
 </package>

--- a/rqt_gui/package.xml
+++ b/rqt_gui/package.xml
@@ -18,8 +18,9 @@
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
 
-  <exec_depend>catkin</exec_depend>
+  <exec_depend>python_qt_binding</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg-modules</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg-modules</exec_depend>
   <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
+  <exec_depend>rospy</exec_depend>
 </package>


### PR DESCRIPTION
Since the `noetic` branch is also the development target branch for `melodic`, we'll need to use a conditional to support both Python versions. Support for conditionals was added in package manifest version 3, so we also need to bump from the version 1 to the version 3 specification.

Here is where rospkg is imported from `rqt_gui`:
https://github.com/ros-visualization/rqt/blob/fd404459cb844f5999c3924f077ff1cb2e5571ef/rqt_gui/src/rqt_gui/main.py#L40

Python 2 rosdep key: [python-rospkg-modules](https://github.com/ros/rosdistro/blob/f31ff576aee5709701b5cbacc650733d83a46ba1/rosdep/python.yaml#L3978-L3999)
Python 3 rosdep key: [python3-rospkg-modules](https://github.com/ros/rosdistro/blob/f31ff576aee5709701b5cbacc650733d83a46ba1/rosdep/python.yaml#L6001-L6020)

Closes #226