### PR TITLE
Fix up the package description.

### DIFF
--- a/rqt/package.xml
+++ b/rqt/package.xml
@@ -1,14 +1,7 @@
 <package format="2">
   <name>rqt</name>
   <version>1.1.3</version>
-  <description>rqt is a Qt-based framework for GUI development for ROS. It consists of three parts/metapackages<br />
-    <ul>
-     <li>rqt (you're here)</li>
-     <li><a href = "http://ros.org/wiki/rqt_common_plugins">rqt_common_plugins</a> - ROS backend tools suite that can be used on/off of robot runtime.</li>
-     <li><a href = "http://ros.org/wiki/rqt_robot_plugins">rqt_robot_plugins</a> - Tools for interacting with robots during their runtime.</li>
-    </ul>
-   rqt metapackage provides a widget <a href = "http://ros.org/wiki/rqt_gui">rqt_gui</a> that enables multiple `rqt` widgets to be docked in a single window.
-  </description>
+  <description>rqt is a Qt-based framework for GUI development for ROS.</description>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>
   <license>BSD</license>
   <url type="website">http://ros.org/wiki/rqt</url>


### PR DESCRIPTION
It described a set of metapackages that we don't actually have.
Just remove most of it here and say that RQt is a Qt-based
GUI development system for ROS.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>