### PR TITLE
rqt_gui_cpp depends on pluginlib, so should declare a dependency.

### DIFF
--- a/rqt_gui_cpp/package.xml
+++ b/rqt_gui_cpp/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>pluginlib</depend>
   <depend>rclcpp</depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>