### PR TITLE
Use underscores instead of dashes in `setup.cfg`

### DIFF
--- a/rqt_gui_py/setup.cfg
+++ b/rqt_gui_py/setup.cfg
@@ -1,2 +1,2 @@
 [install]
-install-scripts=$base/lib/rqt_gui_py
+install_scripts=$base/lib/rqt_gui_py

--- a/rqt_gui_py/setup.cfg
+++ b/rqt_gui_py/setup.cfg
@@ -1,2 +1,4 @@
+[develop]
+script_dir=$base/lib/rqt_gui_py
 [install]
 install_scripts=$base/lib/rqt_gui_py


### PR DESCRIPTION
New `python3-setuptools` warns about this.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>