### PR TITLE
fix build of `rqt` with `setuptools>=v61.0.0`

### DIFF
--- a/rqt/setup.py
+++ b/rqt/setup.py
@@ -28,5 +28,6 @@ setup(
         'rqt_robot_plugins - Tools for interacting with robots during their runtime. ' +
         'rqt_gui - that enables multiple `rqt` widgets to be docked in a single window.'
     ),
+    packages=[],
     license='BSD',
 )


### PR DESCRIPTION
When I tried to compile `rqt` on Gentoo I ran into the following error:
```
--- stderr: rqt
error: Multiple top-level packages discovered in a flat-layout: ['share', 'resource'].

To avoid accidental inclusion of unwanted files or directories,
setuptools will not proceed with this build.

If you are trying to create a single distribution with multiple packages
on purpose, you should not rely on automatic discovery.
Instead, consider the following options:

1. set up custom discovery (`find` directive with `include` or `exclude`)
2. use a `src-layout`
3. explicitly set `py_modules` or `packages` with a list of names

To find more information, look for "package discovery" on setuptools docs.
---
```

This is due to `setuptools` adding automatic discovery in
[`v61.0.0`](https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6100).

The suggested workaround is to set `packages` and/or `py_modules`, which
is done by this commit (I had no preference which to set so I took the
first).