### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/rqt/package.xml
+++ b/rqt/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rqt</name>
   <version>0.5.3</version>
   <description>rqt is a Qt-based framework for GUI development for ROS. It consists of three parts/metapackages<br />
@@ -21,9 +21,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend version_gte="0.3.0">rqt_gui</run_depend>
-  <run_depend version_gte="0.3.0">rqt_gui_cpp</run_depend>
-  <run_depend version_gte="0.3.0">rqt_gui_py</run_depend>
+  <exec_depend version_gte="0.3.0">rqt_gui</exec_depend>
+  <exec_depend version_gte="0.3.0">rqt_gui_cpp</exec_depend>
+  <exec_depend version_gte="0.3.0">rqt_gui_py</exec_depend>
 
   <export>
     <metapackage/>

--- a/rqt/package.xml
+++ b/rqt/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rqt</name>
   <version>0.5.3</version>
   <description>rqt is a Qt-based framework for GUI development for ROS. It consists of three parts/metapackages<br />

--- a/rqt/package.xml
+++ b/rqt/package.xml
@@ -1,4 +1,4 @@
-<package format="3">
+<package>
   <name>rqt</name>
   <version>0.5.3</version>
   <description>rqt is a Qt-based framework for GUI development for ROS. It consists of three parts/metapackages<br />

--- a/rqt_gui/package.xml
+++ b/rqt_gui/package.xml
@@ -13,6 +13,8 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
 

--- a/rqt_gui/setup.py
+++ b/rqt_gui/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 

--- a/rqt_gui_cpp/package.xml
+++ b/rqt_gui_cpp/package.xml
@@ -1,4 +1,4 @@
-<package format="3">
+<package>
   <name>rqt_gui_cpp</name>
   <version>0.5.3</version>
   <description>rqt_gui_cpp enables GUI plugins to use the C++ client library for ROS.</description>

--- a/rqt_gui_cpp/package.xml
+++ b/rqt_gui_cpp/package.xml
@@ -11,8 +11,6 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
   <build_depend version_gte="0.3.0">qt_gui_cpp</build_depend>

--- a/rqt_gui_cpp/package.xml
+++ b/rqt_gui_cpp/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rqt_gui_cpp</name>
   <version>0.5.3</version>
   <description>rqt_gui_cpp enables GUI plugins to use the C++ client library for ROS.</description>
@@ -11,6 +11,8 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
   <build_depend version_gte="0.3.0">qt_gui_cpp</build_depend>
@@ -18,10 +20,10 @@
   <build_depend>roscpp</build_depend>
   <build_depend>nodelet</build_depend>
 
-  <run_depend version_gte="0.3.0">qt_gui</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui_cpp</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>nodelet</run_depend>
+  <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui_cpp</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>nodelet</exec_depend>
 
   <export>
     <cpp cflags="-I${prefix}/include" lflags="-L${prefix}/lib -Wl,-rpath,${prefix}/lib -lrqt_gui_cpp"/>

--- a/rqt_gui_cpp/package.xml
+++ b/rqt_gui_cpp/package.xml
@@ -11,6 +11,8 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
   <build_depend version_gte="0.3.0">qt_gui_cpp</build_depend>

--- a/rqt_gui_cpp/package.xml
+++ b/rqt_gui_cpp/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rqt_gui_cpp</name>
   <version>0.5.3</version>
   <description>rqt_gui_cpp enables GUI plugins to use the C++ client library for ROS.</description>

--- a/rqt_gui_cpp/setup.py
+++ b/rqt_gui_cpp/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/rqt_gui_py/package.xml
+++ b/rqt_gui_py/package.xml
@@ -1,4 +1,4 @@
-<package format="3">
+<package>
   <name>rqt_gui_py</name>
   <version>0.5.3</version>
   <description>rqt_gui_py enables GUI plugins to use the Python client library for ROS.</description>

--- a/rqt_gui_py/package.xml
+++ b/rqt_gui_py/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rqt_gui_py</name>
   <version>0.5.3</version>
   <description>rqt_gui_py enables GUI plugins to use the Python client library for ROS.</description>
@@ -11,14 +11,16 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
   <build_depend version_gte="0.3.0">rqt_gui</build_depend>
   <build_depend>rospy</build_depend>
 
-  <run_depend version_gte="0.3.0">qt_gui</run_depend>
-  <run_depend version_gte="0.3.0">rqt_gui</run_depend>
-  <run_depend>rospy</run_depend>
+  <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
+  <exec_depend version_gte="0.3.0">rqt_gui</exec_depend>
+  <exec_depend>rospy</exec_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/rqt_gui_py/package.xml
+++ b/rqt_gui_py/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rqt_gui_py</name>
   <version>0.5.3</version>
   <description>rqt_gui_py enables GUI plugins to use the Python client library for ROS.</description>

--- a/rqt_gui_py/package.xml
+++ b/rqt_gui_py/package.xml
@@ -11,6 +11,8 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
   <build_depend version_gte="0.3.0">rqt_gui</build_depend>

--- a/rqt_gui_py/package.xml
+++ b/rqt_gui_py/package.xml
@@ -11,8 +11,6 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend version_gte="0.3.0">qt_gui</build_depend>
   <build_depend version_gte="0.3.0">rqt_gui</build_depend>

--- a/rqt_gui_py/setup.py
+++ b/rqt_gui_py/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 

--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -20,6 +20,8 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>genmsg</build_depend>
   <build_depend>std_msgs</build_depend>

--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rqt_py_common</name>
   <version>0.5.3</version>
   <description>
@@ -20,22 +20,24 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>genmsg</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <run_depend>genpy</run_depend>
-  <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
-  <run_depend>qt_gui</run_depend>
-  <run_depend>roslib</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>rostopic</run_depend>
+  <exec_depend>genpy</exec_depend>
+  <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
+  <exec_depend>qt_gui</exec_depend>
+  <exec_depend>roslib</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rostopic</exec_depend>
 
   <!-- 3/11/2013 depending on actionlib & rosbag is only temporary;
   rosaction.py needs it. In the future this run_depend will be removed when
   rosaction gets moved to actionlib. -->
-  <run_depend>actionlib</run_depend>
-  <run_depend>rosbag</run_depend>
+  <exec_depend>actionlib</exec_depend>
+  <exec_depend>rosbag</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -20,8 +20,6 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>genmsg</build_depend>
   <build_depend>std_msgs</build_depend>

--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -1,4 +1,4 @@
-<package format="3">
+<package>
   <name>rqt_py_common</name>
   <version>0.5.3</version>
   <description>

--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rqt_py_common</name>
   <version>0.5.3</version>
   <description>

--- a/rqt_py_common/setup.py
+++ b/rqt_py_common/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.