### PR TITLE
Changes the use of __slots__ for the field and field type getter

### DIFF
--- a/rqt_py_common/src/rqt_py_common/topic_dict.py
+++ b/rqt_py_common/src/rqt_py_common/topic_dict.py
@@ -68,8 +68,8 @@ class TopicDict(object):
             'children': {},
         }
 
-        if hasattr(field, '__slots__'):
-            for child_slot_name in field.__slots__:
+        if hasattr(field, '_fields_and_field_types'):
+            for child_slot_name in field.get_fields_and_field_types().keys():
                 field_dict[slot_name]['children'].update(
                     self._recursive_create_field_dict(
                         child_slot_name, getattr(field, child_slot_name)))

--- a/rqt_py_common/src/rqt_py_common/topic_dict.py
+++ b/rqt_py_common/src/rqt_py_common/topic_dict.py
@@ -61,18 +61,18 @@ class TopicDict(object):
                 self.topic_dict[topic_name].append(
                     self._recursive_create_field_dict(topic_type, message))
 
-    def _recursive_create_field_dict(self, slot_name, field):
+    def _recursive_create_field_dict(self, field_name, field):
         field_dict = {}
-        field_dict[slot_name] = {
+        field_dict[field_name] = {
             'type': type(field),
             'children': {},
         }
 
         if hasattr(field, '_fields_and_field_types'):
-            for child_slot_name in field.get_fields_and_field_types().keys():
-                field_dict[slot_name]['children'].update(
+            for child_field_name in field.get_fields_and_field_types().keys():
+                field_dict[field_name]['children'].update(
                     self._recursive_create_field_dict(
-                        child_slot_name, getattr(field, child_slot_name)))
+                        child_field_name, getattr(field, child_field_name)))
         return field_dict
 
 


### PR DESCRIPTION
This PR modifies the use of `__slots__` for the appropriate message components name _getter_. This changes should solve the problems when [this PR](https://github.com/ros2/rosidl_python/pull/194) is incorporated.