### PR TITLE
fix an exception raised while press ctrl+c to exit

### DIFF
--- a/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py
+++ b/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from python_qt_binding.QtCore import qDebug, QThread, qWarning
+from python_qt_binding.QtCore import qDebug, QThread
 import rclpy
 from rclpy.executors import MultiThreadedExecutor
 

--- a/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py
+++ b/rqt_gui_py/src/rqt_gui_py/rclpy_spinner.py
@@ -30,8 +30,6 @@ class RclpySpinner(QThread):
         executor.add_node(self._node)
         while rclpy.ok() and not self._abort:
             executor.spin_once(timeout_sec=1.0)
-        if not self._abort:
-            qWarning('rclpy.shutdown() was called before QThread.quit()')
 
     def quit(self):  # noqa: A003
         qDebug('Quit called on RclpySpinner')

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -86,5 +86,5 @@ class RosPyPluginProvider(CompositePluginProvider):
     def _destroy_node(self):
         if self._node_initialized:
             self._node.destroy_node()
-            rclpy.shutdown()
+            rclpy.try_shutdown()
             self._node_initialized = False


### PR DESCRIPTION
to fix part of https://github.com/osrf/ros2_test_cases/discussions/1048
`rclpy._rclpy_pybind11.RCLError: failed to shutdown: rcl_shutdown already called on the given context, at ./src/rcl/init.c:313
`
