### PR TITLE
Stop using python_cmake_module.

### DIFF
--- a/rqt_py_common/CMakeLists.txt
+++ b/rqt_py_common/CMakeLists.txt
@@ -18,15 +18,6 @@ if(BUILD_TESTING)
 
   find_package(rosidl_default_generators REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
-  # Provides PYTHON_EXECUTABLE_DEBUG
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra MODULE)
-
-  if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(${PROJECT_NAME}_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-  else()
-    set(${PROJECT_NAME}_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  endif()
 
   # use different project name for generated test interfaces in order to make
   # them importable in the tests beside the Python module of this package
@@ -52,8 +43,8 @@ if(BUILD_TESTING)
   ament_add_pytest_test(${PROJECT_NAME} test
     ENV "AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/ament_index"
     APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py
-    TIMEOUT 90,
-    PYTHON_EXECUTABLE "${${PROJECT_NAME}_PYTHON_EXECUTABLE}")
+    TIMEOUT 90
+  )
 endif()
 
 ament_package()

--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -23,6 +23,7 @@
   <author>Isaac Saito</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <depend>qtbase5-dev</depend>
   <depend>rclpy</depend>

--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -33,7 +33,6 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>python_cmake_module</test_depend>
   <test_depend>rosidl_default_generators</test_depend>
   <test_depend>rosidl_default_runtime</test_depend>
 


### PR DESCRIPTION
We really don't need it anymore, and can just use the builtin find_package(Python3).

This must be merged before https://github.com/ros2/ros2/pull/1524 ; see that pull request for more information about this change.