### PR TITLE
Add a test dependency on pytest.

### DIFF
--- a/rqt/package.xml
+++ b/rqt/package.xml
@@ -20,6 +20,8 @@
   <exec_depend version_gte="0.3.0">rqt_gui_py</exec_depend>
   <exec_depend>rqt_py_common</exec_depend>
 
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/rqt/setup.py
+++ b/rqt/setup.py
@@ -30,4 +30,5 @@ setup(
     ),
     packages=[],
     license='BSD',
+    tests_require=['pytest'],
 )


### PR DESCRIPTION
While there aren't currently tests defined here, this sets it up so that it is ready for pytest tests.

This will also fix the build on Noble, where these are now hard failures rather than just warnings.