### PR TITLE
Allow support for ROS arguments

### DIFF
--- a/rqt_gui/src/rqt_gui/main.py
+++ b/rqt_gui/src/rqt_gui/main.py
@@ -33,7 +33,6 @@ import sys
 
 from qt_gui.main import Main as Base
 from qt_gui.ros_package_helper import get_package_path
-import rclpy
 
 
 class Main(Base):

--- a/rqt_gui/src/rqt_gui/main.py
+++ b/rqt_gui/src/rqt_gui/main.py
@@ -47,8 +47,6 @@ class Main(Base):
         if argv is None:
             argv = sys.argv
 
-        # ignore ROS specific remapping arguments
-        argv = rclpy.utilities.remove_ros_args(args=argv)
         help_text = """<p><b>rqt</b> is a GUI framework that is able to load various plug-in tools
 as dockable windows. There are currently no plug-ins selected. To add plug-ins, select items from
 the <b>Plugins</b> menu.</p>

--- a/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.cpp
+++ b/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.cpp
@@ -35,12 +35,15 @@
 #include <sys/types.h>
 
 #include <stdexcept>
+#include <string.h>
 
 #include "nodelet_plugin_provider.hpp"
 #include <rqt_gui_cpp/plugin.hpp>
 
 #include <qt_gui_cpp/plugin_provider.hpp>
 #include <rclcpp/rclcpp.hpp>
+
+#include <QCoreApplication>
 
 #include <pluginlib/class_list_macros.hpp>
 
@@ -54,8 +57,7 @@ RosCppPluginProvider::RosCppPluginProvider()
   if (rclcpp::ok()) {
     rclcpp_initialized_ = true;
   }
-
-  init_rclcpp();
+  init_rclcpp(QCoreApplication::arguments());
   QList<PluginProvider *> plugin_providers;
   plugin_providers.append(new NodeletPluginProvider("rqt_gui", "rqt_gui_cpp::Plugin"));
   set_plugin_providers(plugin_providers);
@@ -73,7 +75,7 @@ void * RosCppPluginProvider::load(
   qt_gui_cpp::PluginContext * plugin_context)
 {
   qDebug("RosCppPluginProvider::load(%s)", plugin_id.toStdString().c_str());
-  init_rclcpp();
+  init_rclcpp(plugin_context->argv());
   return qt_gui_cpp::CompositePluginProvider::load(plugin_id, plugin_context);
 }
 
@@ -82,23 +84,35 @@ qt_gui_cpp::Plugin * RosCppPluginProvider::load_plugin(
   qt_gui_cpp::PluginContext * plugin_context)
 {
   qDebug("RosCppPluginProvider::load_plugin(%s)", plugin_id.toStdString().c_str());
-  init_rclcpp();
+  init_rclcpp(plugin_context->argv());
   return qt_gui_cpp::CompositePluginProvider::load_plugin(plugin_id, plugin_context);
 }
 
-void RosCppPluginProvider::init_rclcpp()
+void RosCppPluginProvider::init_rclcpp(const QStringList& args)
+{
+  // convert plugin_context.argv() from a QStringList to a char**
+  int argc = args.size();
+  char** argv = new char*[argc];
+  for (int i = 0; i < argc; i++)
+  {
+    argv[i] = strdup(args.at(i).toStdString().c_str());
+  }
+
+  init_rclcpp(argc, argv);
+
+  for (int i = 0; i < argc; i++)
+  {
+    free(argv[i]);
+  }
+}
+void RosCppPluginProvider::init_rclcpp(int argc, char** argv)
 {
   // initialize ROS node once
   if (!rclcpp_initialized_) {
-    int argc = 0;
-    char ** argv = 0;
-
     // Initialize any global resources needed by the middleware and the client library.
-    // This will also parse command line arguments one day (as of Beta 1 they are not used).
     // You must call this before using any other part of the ROS system.
     // This should be called once per process.
     rclcpp::init(argc, argv);
-
 
     // Don't do this again in this process
     rclcpp_initialized_ = true;

--- a/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.hpp
+++ b/rqt_gui_cpp/src/rqt_gui_cpp/roscpp_plugin_provider.hpp
@@ -34,6 +34,7 @@
 #define RQT_GUI_CPP__ROSCPP_PLUGIN_PROVIDER_HPP_
 
 #include <QMessageBox>
+#include <QStringList>
 #include <QThread>
 
 #include <string>
@@ -58,7 +59,8 @@ public:
     qt_gui_cpp::PluginContext * plugin_context);
 
 protected:
-  void init_rclcpp();
+  void init_rclcpp(const QStringList& args);
+  void init_rclcpp(int argc, char** argv);
 
   bool rclcpp_initialized_;
 };

--- a/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
+++ b/rqt_gui_py/src/rqt_gui_py/ros_py_plugin_provider.py
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import sys
 
 from python_qt_binding.QtCore import qDebug, qWarning
 from qt_gui.composite_plugin_provider import CompositePluginProvider
@@ -49,6 +50,7 @@ class RosPyPluginProvider(CompositePluginProvider):
         self._node = None
         self._spinner = None
         self._shutdown_timeout = 2000
+        self._init_node(args=sys.argv)
 
     def shutdown(self):
         qDebug('Shutting down RosPyPluginProvider')
@@ -63,7 +65,7 @@ class RosPyPluginProvider(CompositePluginProvider):
         super().shutdown()
 
     def load(self, plugin_id, plugin_context):
-        self._init_node()
+        self._init_node(args=plugin_context.argv())
         ros_plugin_context = Ros2PluginContext(handler=plugin_context._handler, node=self._node)
 
         return super(RosPyPluginProvider, self).load(plugin_id, ros_plugin_context)
@@ -71,13 +73,13 @@ class RosPyPluginProvider(CompositePluginProvider):
     def unload(self, plugin_instance):
         return super(RosPyPluginProvider, self).unload(plugin_instance)
 
-    def _init_node(self):
+    def _init_node(self, args=None):
         # initialize node once
         if not self._node_initialized:
             name = 'rqt_gui_py_node_%d' % os.getpid()
             qDebug('RosPyPluginProvider._init_node() initialize ROS node "%s"' % name)
             if not rclpy.ok():
-                rclpy.init()
+                rclpy.init(args=args)
             self._node = rclpy.create_node(name)
             self._spinner = RclpySpinner(self._node)
             self._spinner.start()


### PR DESCRIPTION
Enable rqt plugins to receive ROS arguments. This allows plugins to get ROS remappings and ROS parameters.

Relates to https://github.com/ros-visualization/qt_gui_core/pull/301