### PR TITLE
Bump cmake_minimum_required to avoid deprecation

### DIFF
--- a/rqt/CMakeLists.txt
+++ b/rqt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(rqt)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/rqt_gui/CMakeLists.txt
+++ b/rqt_gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(rqt_gui)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS qt_gui)

--- a/rqt_gui_cpp/CMakeLists.txt
+++ b/rqt_gui_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(rqt_gui_cpp)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS qt_gui qt_gui_cpp roscpp nodelet)

--- a/rqt_gui_py/CMakeLists.txt
+++ b/rqt_gui_py/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(rqt_gui_py)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS rqt_gui rospy)

--- a/rqt_py_common/CMakeLists.txt
+++ b/rqt_py_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(rqt_py_common)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED)


### PR DESCRIPTION
Noetic will be EOL very soon and it was already discussed what last changes would be worthwhile.
This was done in [Discourse](https://discourse.ros.org/t/ros-noetic-end-of-life-may-31-2025/43160/4) .
One point was the cmake_minimum_required version because <3.5 is deprecated in newer CMake version.