### PR TITLE
Fix setupTools deprecations

### DIFF
--- a/rqt_gui/setup.py
+++ b/rqt_gui/setup.py
@@ -36,8 +36,8 @@ setup(
     license='BSD',
     extras_require={
         'test': [
-            'pytest'
-        ]
+            'pytest',
+        ],
     },
     entry_points={
         'console_scripts': [

--- a/rqt_gui/setup.py
+++ b/rqt_gui/setup.py
@@ -26,7 +26,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -35,7 +34,11 @@ setup(
         'interface provided by qt_gui.'
     ),
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest'
+        ]
+    },
     entry_points={
         'console_scripts': [
             'rqt = rqt_gui.main:main',

--- a/rqt_gui_py/setup.py
+++ b/rqt_gui_py/setup.py
@@ -30,7 +30,7 @@ setup(
     license='BSD',
     extras_require={
         'test': [
-            'pytest'
-        ]
+            'pytest',
+        ],
     },
 )

--- a/rqt_gui_py/setup.py
+++ b/rqt_gui_py/setup.py
@@ -21,7 +21,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -29,5 +28,9 @@ setup(
         'rqt_gui_py enables GUI plugins to use the Python client library for ROS.'
     ),
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest'
+        ]
+    },
 )


### PR DESCRIPTION
**FIX:**

#UserWarning: Unknown distribution option: 'tests_require'

**and**

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

******************************************************************************** Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: BSD License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. ********************************************************************************