### PR TITLE
Use the same Qt version as qt_gui_cpp

### DIFF
--- a/rqt_gui_cpp/CMakeLists.txt
+++ b/rqt_gui_cpp/CMakeLists.txt
@@ -24,17 +24,11 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
 find_package(pluginlib REQUIRED)
-# Avoid find_package(QT NAMES Qt6 Qt5 ...) due to CMake's default ascending path resolution
-find_package(Qt6 QUIET COMPONENTS Widgets)
-if(Qt6_FOUND)
-  set(QT_VERSION_MAJOR 6)
-else()
-  find_package(Qt5 REQUIRED COMPONENTS Widgets)
-  set(QT_VERSION_MAJOR 5)
-endif()
-set(QT_VERSION "${Qt${QT_VERSION_MAJOR}_VERSION}")
 find_package(rclcpp REQUIRED)
 find_package(qt_gui_cpp REQUIRED)
+
+set(QT_VERSION_MAJOR ${qt_gui_cpp_USE_QT_MAJOR_VERSION})
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 
 ament_export_dependencies(
   rclcpp


### PR DESCRIPTION
Rather than running the detection logic again, just use the version that qt_gui_cpp used, which we must match.